### PR TITLE
Add support for WiFi passwords with the '%' character

### DIFF
--- a/ansible/roles/network/files/screenly_net_mgr.py
+++ b/ansible/roles/network/files/screenly_net_mgr.py
@@ -163,7 +163,7 @@ def get_active_iface(config, prefix):
 
 
 def main():
-    config = configparser.ConfigParser()
+    config = configparser.RawConfigParser()
     config.read(NETWORK_PATH)
 
     logging.info('Started Screenly Network Manager.')


### PR DESCRIPTION
As the default `ConfigParser` does interpolation with the `%` character, WiFi password etc. with this character won't work. This ensures these fields are parsed as-is.