### PR TITLE
Restart websocket layer

### DIFF
--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -85,5 +85,6 @@
 - name: Restart services
   command: /bin/true
   notify:
+    - restart-screenly-websocket_server_layer
     - restart-screenly-server
     - restart-screenly-viewer

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -9,6 +9,9 @@
         name: nginx
         state: restarted
 
+    - name: restart-screenly-websocket_server_layer
+      command: systemctl restart screenly-websocket_server_layer.service
+
     - name: restart-screenly-server
       command: systemctl restart screenly-web.service
 


### PR DESCRIPTION
It is necessary that websocket_server_layer starts after installing Screenly