### PR TITLE
Force periodic reload of repeated web assets

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -307,9 +307,7 @@ def asset_loop(scheduler):
         if 'image' in mime:
             view_image(uri)
         elif 'web' in mime:
-            # FIXME If we want to force periodic reloads of repeated web assets, force=True could be used here.
-            # See e38e6fef3a70906e7f8739294ffd523af6ce66be.
-            browser_url(uri)
+            browser_url(uri, force=True)
         elif 'video' or 'streaming' in mime:
             view_video(uri, asset['duration'])
         else:


### PR DESCRIPTION
This forces Screenly to check whether the file behind the asset has changed periodically. If so, it will update the content accordingly.

My use case: I host a web server linked to a file share. Assets are set up in Screenly as http://x.x.x.x/1.jpg, http://x.x.x.x/2.jpg, etc., pointed towards the web server's IP.
When users want to update or add an image to the rotation for Screenly, they can copy in a new photo to the file share, rename it to (e.g.) 3.jpg, and it will be included shortly afterwards. 
Without this change, when photos were changed in the file share, the asset wasn't updated and the rotation kept playing the same photos.

Signed-off-by: Cooper Worobetz <cooper@worobetz.ca>