### PR TITLE
Next previous buttons

### DIFF
--- a/server.py
+++ b/server.py
@@ -210,7 +210,7 @@ def prepare_asset(request):
     asset['uri'] = uri
 
     if "video" in asset['mimetype']:
-        if int(get('duration')) == 0:
+        if get('duration') == 'N/A' or int(get('duration')) == 0:
             asset['duration'] = int(get_video_duration(uri).total_seconds())
     else:
         # Crashes if it's not an int. We want that.

--- a/static/js/screenly-ose.coffee
+++ b/static/js/screenly-ose.coffee
@@ -550,8 +550,17 @@ API.App = class App extends Backbone.View
       catch error
         no
 
-  events: {'click #add-asset-button': 'add'}
+  events:
+    'click #add-asset-button': 'add',
+    'click #previous-asset-button': 'previous',
+    'click #next-asset-button': 'next'
 
   add: (e) =>
     new AddAssetView
     no
+
+  previous: (e) =>
+    $.get '/api/v1/assets/control/previous'
+
+  next: (e) =>
+    $.get '/api/v1/assets/control/next'

--- a/static/js/screenly-ose.js
+++ b/static/js/screenly-ose.js
@@ -959,6 +959,8 @@
     extend(App, superClass);
 
     function App() {
+      this.next = bind(this.next, this);
+      this.previous = bind(this.previous, this);
       this.add = bind(this.add, this);
       this.initialize = bind(this.initialize, this);
       return App.__super__.constructor.apply(this, arguments);
@@ -1006,12 +1008,22 @@
     };
 
     App.prototype.events = {
-      'click #add-asset-button': 'add'
+      'click #add-asset-button': 'add',
+      'click #previous-asset-button': 'previous',
+      'click #next-asset-button': 'next'
     };
 
     App.prototype.add = function(e) {
       new AddAssetView;
       return false;
+    };
+
+    App.prototype.previous = function(e) {
+      return $.get('/api/v1/assets/control/previous');
+    };
+
+    App.prototype.next = function(e) {
+      return $.get('/api/v1/assets/control/next');
     };
 
     return App;

--- a/templates/index.html
+++ b/templates/index.html
@@ -342,6 +342,14 @@
         <div class="span12">
           <h1 class="page-header">
             <div class="pull-right">
+              <a id="previous-asset-button" class="btn" href="#">
+                <i class="icon-fast-backward"></i>
+                Previous Asset
+              </a>
+              <a id="next-asset-button" class="btn" href="#">
+                <i class="icon-fast-forward"></i>
+                Next Asset
+              </a>
               <a id="add-asset-button" class="btn btn-primary" href="#">
                 <i class="icon-plus icon-white"></i>
                 Add Asset

--- a/viewer.py
+++ b/viewer.py
@@ -84,8 +84,8 @@ class Scheduler(object):
         if not self.assets:
             return None
         if self.reverse:
-            idx = self.index - 2 % len(self.assets)
-            self.index = self.index - 1 % len(self.assets)
+            idx = (self.index - 2) % len(self.assets)
+            self.index = (self.index - 1) % len(self.assets)
             self.reverse = False
         else:
             idx = self.index


### PR DESCRIPTION
Added front-end buttons for next-prev. 
In addition, before https://github.com/Screenly/screenly-ose/commit/0f3df0d80d727c4bc79e54a182d1dd6d57c31057, we often received an incorrect `video` duration ('N/A'). after this, when trying to edit such `videos`, we are getting an error. now it is fixed.

Refs #638 