### PR TITLE
Add support for usb0 device

### DIFF
--- a/ansible/roles/network/files/screenly_net_mgr.py
+++ b/ansible/roles/network/files/screenly_net_mgr.py
@@ -183,6 +183,7 @@ def main():
 
     ethernet = get_active_iface(config, 'eth')
     wifi = get_active_iface(config, 'wlan')
+    usb = get_active_iface(config, 'usb')
 
     if config.has_option('generic', 'dns'):
         dns = config['generic']['dns']
@@ -204,6 +205,24 @@ def main():
                 ip=ethernet_ip,
                 netmask=ethernet_netmask,
                 gateway=ethernet_gateway,
+                dns=dns,
+            )
+
+    if usb:
+        usb_dhcp = is_dhcp(config, usb)
+
+        if usb_dhcp:
+            interfaces += if_config(interface=usb, dns=dns)
+        else:
+            usb_ip = lookup(config, usb, 'ip')
+            usb_netmask = lookup(config, usb, 'netmask')
+            usb_gateway = lookup(config, usb, 'gateway')
+
+            interfaces += if_config(
+                interface=usb,
+                ip=usb_ip,
+                netmask=usb_netmask,
+                gateway=usb_gateway,
                 dns=dns,
             )
 
@@ -239,7 +258,7 @@ def main():
 
     # In case neither wired or wireless is configured,
     # let's just assume wired and dhcp as the default.
-    if not (wifi or ethernet):
+    if not (wifi or ethernet or usb):
         interfaces += if_config(interface='eth0', dns=dns)
 
     write_file(INTERFACES_PATH, interfaces)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -83,7 +83,7 @@ def get_node_ip():
             file_interfaces = open('/etc/network/interfaces')
             iface = 'usb0'
             if iface in file_interfaces.read():
-                interface = iface 
+                interface = iface
 
         if not interface:
             raise Exception("No active network connection found.")

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -79,6 +79,13 @@ def get_node_ip():
                     break
 
         if not interface:
+            """Check to see if we're running in USB gadget mode."""
+            file_interfaces = open('/etc/network/interfaces')
+            iface = 'usb0'
+            if iface in file_interfaces.read():
+                interface = iface 
+
+        if not interface:
             raise Exception("No active network connection found.")
 
         try:
@@ -90,7 +97,7 @@ def get_node_ip():
     else:
         """Returns the node's IP, for the interface
         that is being used as the default gateway.
-        This shuld work on both MacOS X and Linux."""
+        This should work on both MacOS X and Linux."""
         try:
             default_interface = grep(netstat('-nr'), '-e', '^default', '-e' '^0.0.0.0').split()[-1]
             my_ip = ifaddresses(default_interface)[2][0]['addr']


### PR DESCRIPTION
In USB gadget mode, the network interface shows up as usb0.  You might want to use this interface for a Pi Zero running signage near another machine that can provide network connectivity via USB.