### PR TITLE
Fix viewer for Resin

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -52,13 +52,24 @@ def sigusr1(signum, frame):
     omxplayer is killed to skip any currently playing video assets.
     """
     logging.info('USR1 received, skipping.')
-    sh.killall('omxplayer.bin', _ok_code=[1])
+    try:
+        sh.killall('omxplayer.bin', _ok_code=[1])
+    except OSError:
+        pass
 
 
 def sigusr2(signum, frame):
-    scheduler.reverse = True
+    try:
+        scheduler.reverse = True
+    except AttributeError:
+        pass
+
     logging.info('USR1 received, skipping.')
-    sh.killall('omxplayer.bin', _ok_code=[1])
+
+    try:
+        sh.killall('omxplayer.bin', _ok_code=[1])
+    except OSError:
+        pass
 
 
 def sighup(signum, frame):


### PR DESCRIPTION
Apparently, this arose if we pressed back before the `scheduler` was created. for example, while the `splash_page` on the screen. in addition there was a problem if we click on any navigation buttons quickly several times. it was only on Resin

Refs #700 