### PR TITLE
docs: By default, listen on all (more reasonable default for new users)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Assuming you're in the source code repository, simply run:
 
 ```
 $ docker run --rm -ti \
-  -p 8080:8080 \
-  -v $(pwd):/home/pi/screenly \
-  screenly/ose-dev-server
+    --name=screenly-dev \
+    -e 'LISTEN=0.0.0.0' \
+    -p 8080:8080 \
+    -v $(pwd):/home/pi/screenly \
+    screenly/ose-dev-server
 ```
 
 ## Running the Unit Tests


### PR DESCRIPTION
I wasn't able to run the docker image, and found that the docker wasn't listening to connections from my computer, this is a quick hack for it to work. 