### PR TITLE
Fix black screen

### DIFF
--- a/ansible/roles/system/files/10-serverflags.conf
+++ b/ansible/roles/system/files/10-serverflags.conf
@@ -1,0 +1,6 @@
+Section "ServerFlags"
+    Option   "BlankTime" "0"
+    Option   "StandbyTime" "0"
+    Option   "SuspendTime" "0"
+    Option   "OffTime" "0"
+EndSection

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -216,6 +216,14 @@
     owner: root
     group: root
 
+- name: Disable DPMS
+  copy:
+    src: 10-serverflags.conf
+    dest: /usr/share/X11/xorg.conf.d/10-serverflags.conf
+    mode: 0644
+    owner: root
+    group: root
+
 - name: Clear out X11 configs (disables touchpad and other unnecessary things)
   file:
     path: "/usr/share/X11/xorg.conf.d/{{ item }}"


### PR DESCRIPTION
Sometimes disabling DPMS does not work. If you apply these settings, the screen will not darken, even if DPMS is enabled.
Refs #703 