### PR TITLE
Enable offline mode

### DIFF
--- a/ansible/roles/screenly/files/screenly.conf
+++ b/ansible/roles/screenly/files/screenly.conf
@@ -33,6 +33,9 @@ debug_logging = False
 ; Only display pages with proper SSL certificates
 verify_ssl = True
 
+; Run Resin wifi connect if there is no connection
+enable_offline_mode = False
+
 [auth]
 ; If desired, fill in with appropriate username and password
 user=

--- a/settings.py
+++ b/settings.py
@@ -32,6 +32,7 @@ DEFAULTS = {
         'default_streaming_duration': '300',
         'debug_logging': False,
         'verify_ssl': True,
+        'enable_offline_mode': False
     },
     'auth': {
         'user': '',

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -120,6 +120,24 @@
             </div>
 
             <div class="control-group">
+              <label class="control-label">Enable offline mode</label>
+              <div class="controls">
+                <label id="enable_offline_mode" class="checkbox toggle well">
+                  {% if context.enable_offline_mode %}
+                    <input name="enable_offline_mode" checked="checked" type="checkbox" />
+                  {% else %}
+                    <input name="enable_offline_mode" type="checkbox" />
+                  {% endif %}
+                  <p>
+                    <span class="on">On</span>
+                    <span class="off">Off</span>
+                  </p>
+                  <a class="btn btn-primary slide-button"></a>
+                </label>
+              </div>
+            </div>
+
+            <div class="control-group">
               <label class="control-label">Audio output</label>
               <div class="controls">
                 <select class="span2" name="audio_output">

--- a/viewer.py
+++ b/viewer.py
@@ -426,18 +426,14 @@ def setup():
 def main():
     setup()
 
-    if not path.isfile(path.join(HOME, '.screenly/wifi_set')):
-        if not gateways().get('default'):
-            url = 'http://{0}:{1}/hotspot'.format(LISTEN, PORT)
-            load_browser(url=url)
+    if not gateways().get('default') and not settings['enable_offline_mode']:
+        url = 'http://{0}:{1}/hotspot'.format(LISTEN, PORT)
+        load_browser(url=url)
 
-            while not gateways().get('default'):
-                sleep(2)
-            if LISTEN == '127.0.0.1':
-                sh.sudo('nginx')
-
-        with open(path.join(HOME, '.screenly/wifi_set'), 'a'):
-            pass
+        while not gateways().get('default'):
+            sleep(2)
+        if LISTEN == '127.0.0.1':
+            sh.sudo('nginx')
 
     url = 'http://{0}:{1}/splash_page'.format(LISTEN, PORT) if settings['show_splash'] else 'file://' + BLACK_PAGE
     browser_url(url=url)


### PR DESCRIPTION
Added "Enable offline mode" item.
By default if there is no connection, it will be offered to select wifi network (using resin wifi), but if this option is enabled, assets will just start to be displayed.

Refs #764 