### PR TITLE
Use defaults if config file missing.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -66,8 +66,9 @@ class ScreenlySettings(IterableUserDict):
         self.conf_file = self.get_configfile()
 
         if not path.isfile(self.conf_file):
-            logging.error('Config-file %s missing', self.conf_file)
-            exit(1)
+            logging.error('Config-file %s missing. Using defaults.', self.conf_file)
+            self.use_defaults()
+            self.save()
         else:
             self.load()
 
@@ -100,6 +101,13 @@ class ScreenlySettings(IterableUserDict):
         for section, defaults in DEFAULTS.items():
             for field, default in defaults.items():
                 self._get(config, section, field, default)
+    
+    def use_defaults(self):
+        config = ConfigParser.ConfigParser()
+
+        for section, defaults in DEFAULTS.items():
+            for field, default in defaults.items():
+                self[field] = default
 
     def save(self):
         # Write new settings to disk.

--- a/settings.py
+++ b/settings.py
@@ -101,12 +101,10 @@ class ScreenlySettings(IterableUserDict):
         for section, defaults in DEFAULTS.items():
             for field, default in defaults.items():
                 self._get(config, section, field, default)
-    
-    def use_defaults(self):
-        config = ConfigParser.ConfigParser()
 
-        for section, defaults in DEFAULTS.items():
-            for field, default in defaults.items():
+    def use_defaults(self):
+        for defaults in DEFAULTS.items():
+            for field, default in defaults[1].items():
                 self[field] = default
 
     def save(self):


### PR DESCRIPTION
I ran into an issue where my config file wasn't where it was expected. As it was, Screenly-OSE simply crashed with exit(1) rather than just using the defaults. This PR will fix that issue by loading the defaults and saving the configuration file. 