### PR TITLE
Fix issue created by hashing password

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -83,6 +83,8 @@ class ScreenlySettings(IterableUserDict):
                 self[field] = config.getint(section, field)
             else:
                 self[field] = config.get(section, field)
+                if field == 'password' and self[field] != '' and len(self[field]) != 64:   # likely not a hashed password.
+                    self[field] = hashlib.sha256(self[field]).hexdigest()   # hash the original password.
         except ConfigParser.Error as e:
             logging.debug("Could not parse setting '%s.%s': %s. Using default value: '%s'." % (section, field, unicode(e), default))
             self[field] = default


### PR DESCRIPTION
Previous changes I created instituted hashing the password that is stored. However, I found that if the user had already typed in a password and then tried to login, they could never succeed (because what was entered during authentication was hashed before being checked). This corrects that by checking the stored password length and seeing if it is less than 64 (a hashed password length) and if it is it assumes that it needs hashed. Fixes the issue created with #828 