### PR TITLE
Fix issue with unicode metadata on uploaded video.

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -92,7 +92,7 @@ def get_video_duration(file):
     time = None
 
     if arch in ('armv6l', 'armv7l'):
-        run_player = omxplayer(file, info=True, _err_to_out=True, _ok_code=[0, 1])
+        run_player = omxplayer(file, info=True, _err_to_out=True, _ok_code=[0, 1], _decode_errors='ignore')
     else:
         run_player = ffprobe('-i', file, _err_to_out=True)
 


### PR DESCRIPTION
Ran into an issue uploading a movie file created in iMovie. The file had issues decoding unicode stored in the video's metadata. This patch fixes the issue by making it ignore the decoding errors. I only run on a raspberry pi, so I am not sure if the same issue would exist with ffprobe, so I did not include the fix on line 97 as well.