### PR TITLE
Use autoremove parameter from ansible instead of command.

### DIFF
--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -183,7 +183,8 @@
     - system-upgrade
 
 - name: Clean up unused packages
-  command: apt-get -y autoremove
+  apt:
+    autoremove: yes
   tags:
     - system-upgrade
 


### PR DESCRIPTION
Since ansible 2.1 this parameter is available.
https://docs.ansible.com/ansible/latest/modules/apt_module.html