### PR TITLE
hyphenate utf8 for older emacs on jessie

### DIFF
--- a/html_templates.py
+++ b/html_templates.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 
 def black_page(filepath):

--- a/server.py
+++ b/server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 __author__ = "Screenly, Inc"
 __copyright__ = "Copyright 2012-2017, Screenly, Inc"

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 from os import path, getenv
 from sys import exit

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 import datetime
 import functools

--- a/tests/viewer_test.py
+++ b/tests/viewer_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 from nose.tools import ok_, eq_
 from nose.plugins.attrib import attr


### PR DESCRIPTION
I had to fix a problem with a screenly install yesterday.  The emacs on the rpi complained about the "utf8" coding, but "utf-8" seems to work well.