### PR TITLE
Allow the user to specify the ip address for the device in screenly. …

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -78,6 +78,8 @@ def get_node_ip():
         that is being used as the default gateway.
         This should work on both MacOS X and Linux."""
         try:
+            if settings['my_ip'] != '':
+                return settings['my_ip']
             address_family_id = max(list(gateways()['default']))
             default_interface = gateways()['default'][address_family_id][1]
             my_ip = ifaddresses(default_interface)[address_family_id][0]['addr']

--- a/settings.py
+++ b/settings.py
@@ -21,7 +21,8 @@ DEFAULTS = {
         'use_24_hour_clock': False,
         'websocket_port': '9999',
         'use_ssl': False,
-        'analytics_opt_out': False
+        'analytics_opt_out': False,
+        'my_ip': ''
     },
     'viewer': {
         'player_name': '',


### PR DESCRIPTION
…This allows screenly to be used in "offline" mode.