### PR TITLE
Upgrade pep8 to pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ before_script:
 
 script:
   - find . ! -path "*/rtmplite/*" -name \*.py -exec pycodestyle --ignore=E402,E501,E722,E731 {} +
-  #- find . -name \*.py -exec pycodestyle --ignore=E402,E501,E722,E731 {} +
   - nosetests -v -a '!fixme' --with-isolation
   - ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
   - python -m SimpleHTTPServer 8080 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
-  #- find . ! -path "*/rtmplite/*" -name \*.py -exec pycodestyle --ignore=E402,E501,E722,E731 {} +
-  - find . -name \*.py -exec pycodestyle --ignore=E402,E501,E722,E731 {} +
+  - find . ! -path "*/rtmplite/*" -name \*.py -exec pycodestyle --ignore=E402,E501,E722,E731 {} +
+  #- find . -name \*.py -exec pycodestyle --ignore=E402,E501,E722,E731 {} +
   - nosetests -v -a '!fixme' --with-isolation
   - ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
   - python -m SimpleHTTPServer 8080 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
-  - find . ! -path "*/rtmplite/*" -name \*.py -exec pep8 --ignore=E402,E501,E731 {} +
+  - find . ! -path "*/rtmplite/*" -name \*.py -exec pycodestyle --ignore=E402,E501,E731 {} +
   - nosetests -v -a '!fixme' --with-isolation
   - ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
   - python -m SimpleHTTPServer 8080 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
-  - find . ! -path "*/rtmplite/*" -name \*.py -exec pycodestyle --ignore=E402,E501,E731 {} +
+  - find . ! -path "*/rtmplite/*" -name \*.py -exec pycodestyle --ignore=E402,E501,E722,E731 {} +
   - nosetests -v -a '!fixme' --with-isolation
   - ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
   - python -m SimpleHTTPServer 8080 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
-  - find . ! -path "*/rtmplite/*" -name \*.py -exec pycodestyle --ignore=E402,E501,E722,E731 {} +
+  #- find . ! -path "*/rtmplite/*" -name \*.py -exec pycodestyle --ignore=E402,E501,E722,E731 {} +
+  - find . -name \*.py -exec pycodestyle --ignore=E402,E501,E722,E731 {} +
   - nosetests -v -a '!fixme' --with-isolation
   - ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
   - python -m SimpleHTTPServer 8080 &

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To simplify development of the server module of Screenly OSE, we've created a Do
 Assuming you're in the source code repository, simply run:
 
 ```
-$ docker run --rm -ti \
+$ docker run --rm -it \
     --name=screenly-dev \
     -e 'LISTEN=0.0.0.0' \
     -p 8080:8080 \

--- a/bin/migrate.py
+++ b/bin/migrate.py
@@ -85,6 +85,8 @@ def migrate_add_column(col, script):
                 asset.update({'play_order': 0})
                 update(cursor, asset['asset_id'], asset)
                 conn.commit()
+
+
 # ✂--------
 query_create_assets_table = """
 create table assets(

--- a/bin/migrate.py
+++ b/bin/migrate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import sqlite3
 import os
 import shutil
@@ -50,10 +51,13 @@ def test_column(col, cursor):
 
 @contextmanager
 def open_db_get_cursor():
-    with sqlite3.connect(database, detect_types=sqlite3.PARSE_DECLTYPES) as conn:
+    with sqlite3.connect(
+            database,
+            detect_types=sqlite3.PARSE_DECLTYPES) as conn:
         cursor = conn.cursor()
         yield (cursor, conn)
         cursor.close()
+
 
 # ✂--------
 query_add_play_order = """
@@ -72,9 +76,9 @@ commit;
 def migrate_add_column(col, script):
     with open_db_get_cursor() as (cursor, conn):
         if test_column(col, cursor):
-            print 'Column (' + col + ') already present'
+            print('Column (' + col + ') already present')
         else:
-            print 'Adding new column (' + col + ')'
+            print('Adding new column (' + col + ')')
             cursor.executescript(script)
             assets = read(cursor)
             for asset in assets:
@@ -110,11 +114,13 @@ def migrate_make_asset_id_primary_key():
         table_info = cursor.execute('pragma table_info(assets)')
         has_primary_key = table_info.fetchone()[-1] == 1
     if has_primary_key:
-        print 'already has primary key'
+        print('already has primary key')
     else:
         with open_db_get_cursor() as (cursor, _):
             cursor.executescript(query_make_asset_id_primary_key)
-            print 'asset_id is primary key'
+            print('asset_id is primary key')
+
+
 # ✂--------
 query_add_is_enabled_and_nocache = """
 begin transaction;
@@ -137,6 +143,8 @@ def migrate_add_is_enabled_and_nocache():
                 update(cursor, asset['asset_id'], asset)
                 conn.commit()
             print 'Added new columns (' + col + ')'
+
+
 # ✂--------
 query_drop_filename = """BEGIN TRANSACTION;
 CREATE TEMPORARY TABLE assets_backup(asset_id, name, uri, md5, start_date, end_date, duration, mimetype);
@@ -157,8 +165,9 @@ def migrate_drop_filename():
             print 'Dropped obsolete column (' + col + ')'
         else:
             print 'Obsolete column (' + col + ') is not present'
-# ✂--------
 
+
+# ✂--------
 if __name__ == '__main__':
     migrate_drop_filename()
     migrate_add_is_enabled_and_nocache()

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -28,14 +28,16 @@ HTTP_OK = xrange(200, 299)
 # Travis can run.
 try:
     from sh import omxplayer
-except:
+# FIXME find an expected exception
+except Exception:
     pass
 
 # This will work on x86-based machines
 if machine() in ['x86', 'x86_64']:
     try:
         from sh import ffprobe, mplayer
-    except:
+    # FIXME find an expected exception
+    except Exception:
         pass
 
 
@@ -78,10 +80,19 @@ def get_node_ip():
         that is being used as the default gateway.
         This should work on both MacOS X and Linux."""
         try:
-            default_interface = grep(netstat('-nr'), '-e', '^default', '-e' '^0.0.0.0').split()[-1]
+            # FIXME netstat no longer installed by default
+            # on stretch+ systems.  Should we assure net-tools
+            # package installed or use "ip" command to retrieve
+            # default interface?
+            # ip route  | grep ^default | awk '{print $5}'
+            default_interface = grep(netstat('-nr'),
+                                     '-e',
+                                     '^default',
+                                     '-e' '^0.0.0.0').split()[-1]
             my_ip = ifaddresses(default_interface)[2][0]['addr']
             return my_ip
-        except:
+        # FIXME find an expected exception
+        except Exception:
             raise Exception("Unable to resolve local IP address.")
 
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -29,7 +29,7 @@ HTTP_OK = xrange(200, 299)
 try:
     from sh import omxplayer
 # FIXME find an expected exception
-except Exception:
+except BaseException:
     pass
 
 # This will work on x86-based machines
@@ -37,7 +37,7 @@ if machine() in ['x86', 'x86_64']:
     try:
         from sh import ffprobe, mplayer
     # FIXME find an expected exception
-    except Exception:
+    except BaseException:
         pass
 
 
@@ -92,7 +92,7 @@ def get_node_ip():
             my_ip = ifaddresses(default_interface)[2][0]['addr']
             return my_ip
         # FIXME find an expected exception
-        except Exception:
+        except BaseException:
             raise Exception("Unable to resolve local IP address.")
 
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
-nose==1.2.1
 mock==1.0.1
-pep8==1.7.0
+nose==1.2.1
+pycodestyle==2.4.0
 selenium==2.53.6
 setuptools==34.4.0
 splinter==0.7.4

--- a/server.py
+++ b/server.py
@@ -100,7 +100,7 @@ def is_up_to_date():
         with open(sha_file, 'r') as f:
             latest_sha = f.read().strip()
     # FIXME find an expected exception
-    except Exception:
+    except BaseException:
         latest_sha = None
 
     if latest_sha:
@@ -976,7 +976,7 @@ class Info(Resource):
             viewlog = [line.decode('utf-8') for line in
                        check_output(cmd).split('\n')]
         # FIXME find an expected exception
-        except Exception:
+        except BaseException:
             pass
 
         # Calculate disk space
@@ -1100,7 +1100,7 @@ api.add_resource(ResetWifiConfig, '/api/v1/reset_wifi')
 try:
     my_ip = get_node_ip()
 # FIXME find an expected exception
-except Exception:
+except BaseException:
     pass
 else:
     SWAGGER_URL = '/api/docs'
@@ -1260,12 +1260,13 @@ def settings_page():
 def system_info():
     viewlog = None
     # FIXME still new to systemd  is sudo really necessary for
-    # systemctl status?
+    # systemctl status? Was the fact that jessie wears a red hat
+    # an inside joke?
     try:
         viewlog = [line.decode('utf-8') for line in
                    check_output(['sudo', 'systemctl', 'status', 'screenly-viewer.service', '-n', '20']).split('\n')]  # noqa
     # FIXME find an expected execption
-    except Exception:
+    except BaseException:
         pass
 
     loadavg = diagnostics.get_load_avg()['15 min']

--- a/server.py
+++ b/server.py
@@ -12,17 +12,24 @@ from hurry.filesize import size
 import json
 from mimetypes import guess_type
 from os import getenv, makedirs, mkdir, path, remove, rename, statvfs
-from pwgen import pwgen
-import sh
+# FIXME unused imports (consider using flake8 to find these types of problems)
+# from pwgen import pwgen
+# import sh
 from sh import git
 from subprocess import check_output
-from time import sleep
+# from time import sleep
 import traceback
 import uuid
 import hashlib
 from base64 import b64encode
 
-from flask import Flask, make_response, render_template, request, send_from_directory
+from flask import (
+    Flask,
+    make_response,
+    render_template,
+    request,
+    send_from_directory,
+)
 from flask_cors import CORS
 from flask_restful_swagger_2 import Api, Resource, Schema, swagger
 from flask_swagger_ui import get_swaggerui_blueprint
@@ -42,7 +49,15 @@ from lib.utils import download_video_from_youtube, json_dump
 from lib.utils import url_fails
 from lib.utils import validate_url
 
-from settings import auth_basic, CONFIGURABLE_SETTINGS, DEFAULTS, LISTEN, PORT, settings, ZmqPublisher
+from settings import (
+    auth_basic,
+    CONFIGURABLE_SETTINGS,
+    DEFAULTS,
+    LISTEN,
+    PORT,
+    settings,
+    ZmqPublisher,
+)
 
 
 HOME = getenv('HOME', '/home/pi')
@@ -84,7 +99,8 @@ def is_up_to_date():
     try:
         with open(sha_file, 'r') as f:
             latest_sha = f.read().strip()
-    except:
+    # FIXME find an expected exception
+    except Exception:
         latest_sha = None
 
     if latest_sha:
@@ -105,9 +121,10 @@ def template(template_name, **context):
 
     # Add global contexts
     context['up_to_date'] = is_up_to_date()
-    context['default_duration'] = settings['default_duration']
-    context['default_streaming_duration'] = settings['default_streaming_duration']
-    context['use_24_hour_clock'] = settings['use_24_hour_clock']
+    for opt in ['default_duration',
+                'default_streaming_duration',
+                'use_24_hour_clock']:
+        context[opt] = settings[opt]
     context['template_settings'] = {
         'imports': ['from lib.utils import template_handle_unicode'],
         'default_filters': ['template_handle_unicode'],
@@ -187,7 +204,8 @@ class AssetRequestModel(Schema):
             'format': 'int64',
         }
     }
-    required = ['name', 'uri', 'mimetype', 'is_enabled', 'start_date', 'end_date']
+    required = ['name', 'uri', 'mimetype',
+                'is_enabled', 'start_date', 'end_date']
 
 
 class AssetContentModel(Schema):
@@ -231,7 +249,7 @@ def prepare_asset(request):
             return val
 
     if not all([get('name'), get('uri'), get('mimetype')]):
-        raise Exception("Not enough information provided. Please specify 'name', 'uri', and 'mimetype'.")
+        raise Exception("Not enough information provided. Please specify 'name', 'uri', and 'mimetype'.")  # noqa
 
     asset = {
         'name': get('name'),
@@ -258,7 +276,8 @@ def prepare_asset(request):
             uri = path.join(settings['assetdir'], asset['asset_id'])
 
     if 'youtube_asset' in asset['mimetype']:
-        uri, asset['name'], asset['duration'] = download_video_from_youtube(uri, asset['asset_id'])
+        uri, asset['name'], asset['duration'] = download_video_from_youtube(
+            uri, asset['asset_id'])
         asset['mimetype'] = 'video'
         asset['is_processing'] = 1
 
@@ -273,12 +292,14 @@ def prepare_asset(request):
 
     # parse date via python-dateutil and remove timezone info
     if get('start_date'):
-        asset['start_date'] = date_parser.parse(get('start_date')).replace(tzinfo=None)
+        asset['start_date'] = date_parser.parse(
+            get('start_date')).replace(tzinfo=None)
     else:
         asset['start_date'] = ""
 
     if get('end_date'):
-        asset['end_date'] = date_parser.parse(get('end_date')).replace(tzinfo=None)
+        asset['end_date'] = date_parser.parse(
+            get('end_date')).replace(tzinfo=None)
     else:
         asset['end_date'] = ""
 
@@ -305,7 +326,7 @@ def prepare_asset_v1_2(request, asset_id=None):
                 str(get('is_enabled')),
                 get('start_date'),
                 get('end_date')]):
-        raise Exception("Not enough information provided. Please specify 'name', 'uri', 'mimetype', 'is_enabled', 'start_date' and 'end_date'.")
+        raise Exception("Not enough information provided. Please specify 'name', 'uri', 'mimetype', 'is_enabled', 'start_date' and 'end_date'.")  # noqa
 
     asset = {
         'name': get('name'),
@@ -330,7 +351,8 @@ def prepare_asset_v1_2(request, asset_id=None):
             uri = path.join(settings['assetdir'], asset['asset_id'])
 
     if 'youtube_asset' in asset['mimetype']:
-        uri, asset['name'], asset['duration'] = download_video_from_youtube(uri, asset['asset_id'])
+        uri, asset['name'], asset['duration'] = download_video_from_youtube(
+            uri, asset['asset_id'])
         asset['mimetype'] = 'video'
         asset['is_processing'] = 1
 
@@ -348,8 +370,10 @@ def prepare_asset_v1_2(request, asset_id=None):
     asset['play_order'] = get('play_order') if get('play_order') else 0
 
     # parse date via python-dateutil and remove timezone info
-    asset['start_date'] = date_parser.parse(get('start_date')).replace(tzinfo=None)
-    asset['end_date'] = date_parser.parse(get('end_date')).replace(tzinfo=None)
+    asset['start_date'] = date_parser.parse(
+        get('start_date')).replace(tzinfo=None)
+    asset['end_date'] = date_parser.parse(
+        get('end_date')).replace(tzinfo=None)
 
     return asset
 
@@ -395,7 +419,8 @@ class Assets(Resource):
                 'type': 'string',
                 'description':
                     '''
-                    Yes, that is just a string of JSON not JSON itself it will be parsed on the other end.
+                    Yes, that is just a string of JSON not JSON itself \
+                    it will be parsed on the other end.
                     Content-Type: application/x-www-form-urlencoded
                     model: "{
                         "name": "Website",
@@ -689,12 +714,14 @@ class AssetsV1_2(Resource):
             raise Exception("Could not retrieve file. Check the asset URL.")
         with db.conn(settings['database']) as conn:
             assets = assets_helper.read(conn)
-            ids_of_active_assets = [x['asset_id'] for x in assets if x['is_active']]
+            ids_of_active_assets = [x['asset_id'] for x in assets
+                                    if x['is_active']]
 
             asset = assets_helper.create(conn, asset)
 
             if asset['is_active']:
-                ids_of_active_assets.insert(asset['play_order'], asset['asset_id'])
+                ids_of_active_assets.insert(asset['play_order'],
+                                            asset['asset_id'])
             assets_helper.save_ordering(conn, ids_of_active_assets)
             return assets_helper.read(conn, asset['asset_id']), 201
 
@@ -750,7 +777,8 @@ class AssetV1_2(Resource):
         asset = prepare_asset_v1_2(request, asset_id)
         with db.conn(settings['database']) as conn:
             assets = assets_helper.read(conn)
-            ids_of_active_assets = [x['asset_id'] for x in assets if x['is_active']]
+            ids_of_active_assets = [x['asset_id'] for x in assets
+                                    if x['is_active']]
 
             asset = assets_helper.update(conn, asset_id, asset)
 
@@ -759,7 +787,8 @@ class AssetV1_2(Resource):
             except ValueError:
                 pass
             if asset['is_active']:
-                ids_of_active_assets.insert(asset['play_order'], asset['asset_id'])
+                ids_of_active_assets.insert(asset['play_order'],
+                                            asset['asset_id'])
 
             assets_helper.save_ordering(conn, ids_of_active_assets)
             return assets_helper.read(conn, asset_id)
@@ -848,7 +877,9 @@ class PlaylistOrder(Resource):
                 'description':
                     '''
                     Content-Type: application/x-www-form-urlencoded
-                    ids: "793406aa1fd34b85aa82614004c0e63a,1c5cfa719d1f4a9abae16c983a18903b,9c41068f3b7e452baf4dc3f9b7906595"
+                    ids: "793406aa1fd34b85aa82614004c0e63a,\
+                    1c5cfa719d1f4a9abae16c983a18903b,\
+                    9c41068f3b7e452baf4dc3f9b7906595"
                     comma separated ids
                     '''
             },
@@ -861,7 +892,8 @@ class PlaylistOrder(Resource):
     })
     def post(self):
         with db.conn(settings['database']) as conn:
-            assets_helper.save_ordering(conn, request.form.get('ids', '').split(','))
+            idlist = request.form.get('ids', '').split(',')
+            assets_helper.save_ordering(conn, idlist)
 
 
 class Backup(Resource):
@@ -938,10 +970,13 @@ class Info(Resource):
 
     def get(self):
         viewlog = None
+        cmd = ['sudo', 'systemctl', 'status', 'screenly-viewer.service',
+               '-n', '20']
         try:
             viewlog = [line.decode('utf-8') for line in
-                       check_output(['sudo', 'systemctl', 'status', 'screenly-viewer.service', '-n', '20']).split('\n')]
-        except:
+                       check_output(cmd).split('\n')]
+        # FIXME find an expected exception
+        except Exception:
             pass
 
         # Calculate disk space
@@ -1007,7 +1042,8 @@ class AssetContent(Resource):
 
                 'type' can either be 'file' or 'url'.
 
-                In case of a file, the fields 'mimetype', 'filename', and 'content'  will be present.
+                In case of a file, the fields 'mimetype', 'filename', \
+                and 'content'  will be present.
                 In case of a URL, the field 'url' will be present.
                 ''',
                 'schema': AssetContentModel
@@ -1063,7 +1099,8 @@ api.add_resource(ResetWifiConfig, '/api/v1/reset_wifi')
 
 try:
     my_ip = get_node_ip()
-except:
+# FIXME find an expected exception
+except Exception:
     pass
 else:
     SWAGGER_URL = '/api/docs'
@@ -1108,7 +1145,9 @@ def viewIndex():
     if resin_uuid:
         ws_addresses.append('wss://{}.resindevice.io/ws/'.format(resin_uuid))
 
-    return template('index.html', ws_addresses=ws_addresses, player_name=player_name)
+    return template('index.html',
+                    ws_addresses=ws_addresses,
+                    player_name=player_name)
 
 
 @app.route('/settings', methods=["GET", "POST"])
@@ -1119,13 +1158,17 @@ def settings_page():
 
     if request.method == "POST":
         try:
-            # put some request variables in local variables to make easier to read
+            # put some request variables in local variables
+            # to make easier to read
             current_pass = request.form.get('curpassword', '')
             new_pass = request.form.get('password', '')
             new_pass2 = request.form.get('password2', '')
-            current_pass = '' if current_pass == '' else hashlib.sha256(current_pass).hexdigest()
-            new_pass = '' if new_pass == '' else hashlib.sha256(new_pass).hexdigest()
-            new_pass2 = '' if new_pass2 == '' else hashlib.sha256(new_pass2).hexdigest()
+            if current_pass != '':
+                current_pass = hashlib.sha256(current_pass).hexdigest()
+            if new_pass != '':
+                new_pass = hashlib.sha256(new_pass).hexdigest()
+            if new_pass2 != '':
+                new_pass2 = hashlib.sha256(new_pass2).hexdigest()
 
             new_user = request.form.get('user', '')
             use_auth = request.form.get('use_auth', '') == 'on'
@@ -1133,11 +1176,12 @@ def settings_page():
             # Handle auth components
             if settings['password'] != '':    # if password currently set,
                 if new_user != settings['user']:    # trying to change user
-                    # should have current password set. Optionally may change password.
+                    # should have current password set.
+                    # Optionally may change password.
                     if current_pass == '':
                         if not use_auth:
-                            raise ValueError("Must supply current password to disable authentication")
-                        raise ValueError("Must supply current password to change username")
+                            raise ValueError("Must supply current password to disable authentication")  # noqa
+                        raise ValueError("Must supply current password to change username")  # noqa
                     if current_pass != settings['password']:
                         raise ValueError("Incorrect current password.")
 
@@ -1145,7 +1189,8 @@ def settings_page():
 
                 if new_pass != '' and use_auth:
                     if current_pass == '':
-                        raise ValueError("Must supply current password to change password")
+                        raise ValueError(
+                            "Must supply current password to change password")
                     if current_pass != settings['password']:
                         raise ValueError("Incorrect current password.")
 
@@ -1157,7 +1202,7 @@ def settings_page():
                 if new_pass == '' and not use_auth and new_pass2 == '':
                     # trying to disable authentication
                     if current_pass == '':
-                        raise ValueError("Must supply current password to disable authentication")
+                        raise ValueError("Must supply current password to disable authentication")  # noqa
                     settings['password'] = ''
 
             else:        # no current password
@@ -1183,7 +1228,8 @@ def settings_page():
             settings.save()
             publisher = ZmqPublisher.get_instance()
             publisher.send_to_viewer('reload')
-            context['flash'] = {'class': "success", 'message': "Settings were successfully saved."}
+            context['flash'] = {'class': "success",
+                                'message': "Settings were successfully saved."}
         except ValueError as e:
             context['flash'] = {'class': "danger", 'message': e}
         except IOError as e:
@@ -1197,8 +1243,9 @@ def settings_page():
 
     context['user'] = settings['user']
     context['password'] = "password" if settings['password'] != "" else ""
-
-    context['reset_button_state'] = "disabled" if path.isfile(path.join(HOME, DISABLE_MANAGE_NETWORK)) else ""
+    context['reset_button_state'] = ""
+    if path.isfile(path.join(HOME, DISABLE_MANAGE_NETWORK)):
+        context['reset_button_state'] = 'disabled'
 
     if not settings['user'] or not settings['password']:
         context['use_auth'] = False
@@ -1212,10 +1259,13 @@ def settings_page():
 @auth_basic
 def system_info():
     viewlog = None
+    # FIXME still new to systemd  is sudo really necessary for
+    # systemctl status?
     try:
         viewlog = [line.decode('utf-8') for line in
-                   check_output(['sudo', 'systemctl', 'status', 'screenly-viewer.service', '-n', '20']).split('\n')]
-    except:
+                   check_output(['sudo', 'systemctl', 'status', 'screenly-viewer.service', '-n', '20']).split('\n')]  # noqa
+    # FIXME find an expected execption
+    except Exception:
         pass
 
     loadavg = diagnostics.get_load_avg()['15 min']
@@ -1286,7 +1336,9 @@ def mistake404(code):
 @app.route('/static_with_mime/<string:path>')
 def static_with_mime(path):
     mimetype = request.args['mime'] if 'mime' in request.args else 'auto'
-    return send_from_directory(directory='static', filename=path, mimetype=mimetype)
+    return send_from_directory(directory='static',
+                               filename=path,
+                               mimetype=mimetype)
 
 
 if __name__ == "__main__":

--- a/tests/rtmplite/amf.py
+++ b/tests/rtmplite/amf.py
@@ -1,427 +1,655 @@
 # Copyright (c) 2011, Kundan Singh. All rights reserved. see README for details.
-# 
-# Implementation of 
+#
+# Implementation of
 # http://opensource.adobe.com/wiki/download/attachments/1114283/amf0_spec_121207.pdf
 # http://opensource.adobe.com/wiki/download/attachments/1114283/amf3_spec_121207.pdf
 
-import struct, datetime, time, types
+import struct
+import datetime
+import time
+import types
 from StringIO import StringIO
 import xml.etree.ElementTree as ET
 
-class Object(object): # a typed object or received object. Typed object has _classname attr.
+
+# a typed object or received object. Typed object has _classname attr.
+class Object(object):
     def __init__(self, **kwargs):
-        for key, val in kwargs.items(): setattr(self, key, val)
+        for key, val in kwargs.items():
+            setattr(self, key, val)
+
 
 class Class:
     __slots__ = ('name', 'encoding', 'attrs')
 
+
 class _Undefined(object):
-    def __nonzero__(self): return False # always treated as False
+    def __nonzero__(self): return False  # always treated as False
+
     def __repr__(self): return 'amf.undefined'
+
 
 undefined = _Undefined()  # received undefined is different from null (None)
 
 
-class BytesIO(StringIO): # raise EOFError if needed, allow read with optional length, and peek next byte
-    def __init__(self, *args, **kwargs): StringIO.__init__(self, *args, **kwargs)
-    def eof(self): return self.tell() >= self.len  # return true if next read will cause EOFError
-    def remaining(self): return self.len - self.tell() # return number of remaining bytes
-    
+# raise EOFError if needed, allow read with optional length, and peek next byte
+class BytesIO(StringIO):
+    def __init__(self, *args, **kwargs): StringIO.__init__(self,
+                                                           *args, **kwargs)
+
+    # return true if next read will cause EOFError
+    def eof(self): return self.tell() >= self.len
+
+    # return number of remaining bytes
+    def remaining(self): return self.len - self.tell()
+
     def read(self, length=-1):
-        if length > 0 and self.eof(): raise EOFError # raise error if reading beyond EOF
-        if length > 0 and self.tell() + length > self.len: length = self.len - self.tell() # don't read more than available bytes
+        if length > 0 and self.eof():
+            raise EOFError  # raise error if reading beyond EOF
+        if length > 0 and self.tell() + length > self.len:
+            length = self.len - self.tell()  # don't read more than available bytes
         return StringIO.read(self, length)
+
     def peek(self):
-        if self.eof(): return None
+        if self.eof():
+            return None
         else:
             c = self.read(1)
             self.seek(self.tell()-1)
             return c
-        
+
     for type, T, bytes in (('u8', 'B', 1), ('s8', 'b', 1), ('u16', 'H', 2), ('s16', 'h', 2), ('u32', 'L', 4), ('s32', 'l', 4), ('double', 'd', 8)):
-        exec '''def read_%s(self): return struct.unpack("!%s", self.read(%d))[0]'''%(type, T, bytes)
-        exec '''def write_%s(self, c): self.write(struct.pack("!%s", c))'''%(type, T)
-        
+        exec '''def read_%s(self): return struct.unpack("!%s", self.read(%d))[0]''' % (type, T, bytes)
+        exec '''def write_%s(self, c): self.write(struct.pack("!%s", c))''' % (type, T)
+
     def read_utf8(self, length): return unicode(self.read(length), 'utf8')
+
     def write_utf8(self, c): self.write(c.encode('utf8'))
-    
+
     def read_u29(self):
-        n = result = 0; b = self.read_u8()
-        while b & 0x80 and n < 3: result <<= 7; result |= b & 0x7f; b = self.read_u8(); n += 1
-        if n < 3: result <<= 7; result |= b
-        else: result <<= 8; result |= b
+        n = result = 0
+        b = self.read_u8()
+        while b & 0x80 and n < 3:
+            result <<= 7
+            result |= b & 0x7f
+            b = self.read_u8()
+            n += 1
+        if n < 3:
+            result <<= 7
+            result |= b
+        else:
+            result <<= 8
+            result |= b
         assert result & 0xe0000000 == 0
         return result
+
     def read_s29(self):
         result = self.read_u29()
-        if result & 0x10000000: result -= 0x20000000
+        if result & 0x10000000:
+            result -= 0x20000000
         return result
+
     def write_u29(self, c):
-        if c < 0 or c > 0x1fffffff: raise ValueError('uint29 out of range')
+        if c < 0 or c > 0x1fffffff:
+            raise ValueError('uint29 out of range')
         bytes = ''
-        if c >= 0x200000: bytes += chr(0x80 | ((c >> 22) & 0x7f))
-        if c >= 0x4000: bytes += chr(0x80 | ((c >> 15) & 0x7f))
-        if c >= 0x80: bytes += chr(0x80 | ((c >> 8) & 0x7f))
-        if c >= 0x200000: bytes += chr(c & 0xff)
-        else: bytes += chr(c & 0x7f)
+        if c >= 0x200000:
+            bytes += chr(0x80 | ((c >> 22) & 0x7f))
+        if c >= 0x4000:
+            bytes += chr(0x80 | ((c >> 15) & 0x7f))
+        if c >= 0x80:
+            bytes += chr(0x80 | ((c >> 8) & 0x7f))
+        if c >= 0x200000:
+            bytes += chr(c & 0xff)
+        else:
+            bytes += chr(c & 0x7f)
         self.write(bytes)
+
     def write_s29(self, c):
-        if c < -0x10000000 or c > 0x0fffffff: raise ValueError('sint29 out of range')
-        if c < 0: c += 0x20000000
+        if c < -0x10000000 or c > 0x0fffffff:
+            raise ValueError('sint29 out of range')
+        if c < 0:
+            c += 0x20000000
         self.write_u29(c)
 
 
 class AMF0(object):
-    NUMBER, BOOL, STRING, OBJECT, MOVIECLIP, NULL, UNDEFINED, REFERENCE, ECMA_ARRAY, OBJECT_END, ARRAY, DATE, LONG_STRING, UNSUPPORTED, RECORDSET, XML, TYPED_OBJECT, TYPE_AMF3 = range(0x12)
+    NUMBER, BOOL, STRING, OBJECT, MOVIECLIP, NULL, UNDEFINED, REFERENCE, ECMA_ARRAY, OBJECT_END, ARRAY, DATE, LONG_STRING, UNSUPPORTED, RECORDSET, XML, TYPED_OBJECT, TYPE_AMF3 = range(
+        0x12)
 
     def __init__(self, data=None):
-        self._obj_refs, self.data = list(), data if isinstance(data, BytesIO) else BytesIO(data) if data is not None else BytesIO()
-    def _created(self, obj): # new object-reference is created
-        self._obj_refs.append(obj); return obj
+        self._obj_refs, self.data = list(), data if isinstance(
+            data, BytesIO) else BytesIO(data) if data is not None else BytesIO()
+
+    def _created(self, obj):  # new object-reference is created
+        self._obj_refs.append(obj)
+        return obj
+
     def read(self):
         global undefined
         marker = self.data.read_u8()
-        if   marker == AMF0.NUMBER:   return self.data.read_double()
-        elif marker == AMF0.BOOL:     return bool(self.data.read_u8())
-        elif marker == AMF0.STRING:   return self.readString()
-        elif marker == AMF0.OBJECT:   return self.readObject()
-        elif marker == AMF0.MOVIECLIP:raise NotImplementedError()
-        elif marker == AMF0.NULL:     return None
-        elif marker == AMF0.UNDEFINED:return undefined
-        elif marker == AMF0.REFERENCE:return self.readReference()
-        elif marker == AMF0.ECMA_ARRAY:return self.readEcmaArray()
-        elif marker == AMF0.ARRAY:    return self.readArray() 
-        elif marker == AMF0.DATE:     return self.readDate()
-        elif marker == AMF0.LONG_STRING:return self.readLongString()
-        elif marker == AMF0.UNSUPPORTED:return None
-        elif marker == AMF0.RECORDSET:raise NotImplementedError()
-        elif marker == AMF0.XML:      return self.readXML()
-        elif marker == AMF0.TYPED_OBJECT: return self.readTypedObject()
-        elif marker == AMF0.TYPE_AMF3: return AMF3(self.data).read()
-        else: raise ValueError('Invalid AMF0 marker 0x%02x at %d' % (marker, self.data.tell()-1))
-        
+        if marker == AMF0.NUMBER:
+            return self.data.read_double()
+        elif marker == AMF0.BOOL:
+            return bool(self.data.read_u8())
+        elif marker == AMF0.STRING:
+            return self.readString()
+        elif marker == AMF0.OBJECT:
+            return self.readObject()
+        elif marker == AMF0.MOVIECLIP:
+            raise NotImplementedError()
+        elif marker == AMF0.NULL:
+            return None
+        elif marker == AMF0.UNDEFINED:
+            return undefined
+        elif marker == AMF0.REFERENCE:
+            return self.readReference()
+        elif marker == AMF0.ECMA_ARRAY:
+            return self.readEcmaArray()
+        elif marker == AMF0.ARRAY:
+            return self.readArray()
+        elif marker == AMF0.DATE:
+            return self.readDate()
+        elif marker == AMF0.LONG_STRING:
+            return self.readLongString()
+        elif marker == AMF0.UNSUPPORTED:
+            return None
+        elif marker == AMF0.RECORDSET:
+            raise NotImplementedError()
+        elif marker == AMF0.XML:
+            return self.readXML()
+        elif marker == AMF0.TYPED_OBJECT:
+            return self.readTypedObject()
+        elif marker == AMF0.TYPE_AMF3:
+            return AMF3(self.data).read()
+        else:
+            raise ValueError('Invalid AMF0 marker 0x%02x at %d' %
+                             (marker, self.data.tell()-1))
+
     def write(self, data):
         global undefined
-        if   data is None:                         self.data.write_u8(AMF0.NULL)
-        elif data == undefined:                    self.data.write_u8(AMF0.UNDEFINED)
-        elif isinstance(data, bool):               self.data.write_u8(AMF0.BOOL); self.data.write_u8(1 if data else 0)
-        elif isinstance(data, (int, long, float)): self.data.write_u8(AMF0.NUMBER); self.data.write_double(float(data))
-        elif isinstance(data, types.StringTypes):  self.writeString(data)
-        elif isinstance(data, (types.ListType, types.TupleType)): self.writeArray(data)
-        elif isinstance(data, (datetime.date, datetime.datetime)): self.writeDate(data)
-        elif isinstance(data, ET._ElementInterface): self.writeXML(data)
-        elif isinstance(data, types.DictType):     self.writeEcmaArray(data)
-        elif isinstance(data, Object) and hasattr(data, '_classname'): self.writeTypedObject(data)
-        elif isinstance(data, (Object, object)):   self.writeObject(data)
-        else: raise ValueError('Invalid AMF0 data %r type %r' % (data, type(data)))
+        if data is None:
+            self.data.write_u8(AMF0.NULL)
+        elif data == undefined:
+            self.data.write_u8(AMF0.UNDEFINED)
+        elif isinstance(data, bool):
+            self.data.write_u8(AMF0.BOOL)
+            self.data.write_u8(1 if data else 0)
+        elif isinstance(data, (int, long, float)):
+            self.data.write_u8(AMF0.NUMBER)
+            self.data.write_double(float(data))
+        elif isinstance(data, types.StringTypes):
+            self.writeString(data)
+        elif isinstance(data, (types.ListType, types.TupleType)):
+            self.writeArray(data)
+        elif isinstance(data, (datetime.date, datetime.datetime)):
+            self.writeDate(data)
+        elif isinstance(data, ET._ElementInterface):
+            self.writeXML(data)
+        elif isinstance(data, types.DictType):
+            self.writeEcmaArray(data)
+        elif isinstance(data, Object) and hasattr(data, '_classname'):
+            self.writeTypedObject(data)
+        elif isinstance(data, (Object, object)):
+            self.writeObject(data)
+        else:
+            raise ValueError('Invalid AMF0 data %r type %r' %
+                             (data, type(data)))
 
     def readString(self): return self.data.read_utf8(self.data.read_u16())
+
     def readLongString(self): return self.data.read_utf8(self.data.read_u32())
+
     def writeString(self, data, writeType=True):
-        data = unicode(data).encode('utf8') if isinstance(data, unicode) else data
-        if writeType: self.data.write_u8(AMF0.LONG_STRING if len(data) > 0xffff else AMF0.STRING)
-        if len(data) > 0xffff: self.data.write_u32(len(data))
-        else: self.data.write_u16(len(data))
+        data = unicode(data).encode(
+            'utf8') if isinstance(data, unicode) else data
+        if writeType:
+            self.data.write_u8(AMF0.LONG_STRING if len(data)
+                               > 0xffff else AMF0.STRING)
+        if len(data) > 0xffff:
+            self.data.write_u32(len(data))
+        else:
+            self.data.write_u16(len(data))
         self.data.write(data)
-        
+
     def readObject(self):
         obj, key = self._created(Object()), self.readString()
         while key != '' or self.data.peek() != chr(AMF0.OBJECT_END):
-            setattr(obj, key, self.read()); key = self.readString()
-        self.data.read(1) # discard OBJECT_END
+            setattr(obj, key, self.read())
+            key = self.readString()
+        self.data.read(1)  # discard OBJECT_END
         return obj
+
     def writeObject(self, data):
         if not self.writePossibleReference(data):
             self.data.write_u8(AMF0.OBJECT)
-            for key, val in data.__dict__.items(): 
-                if not key.startswith('_'): self.writeString(key, False); self.write(val)
-            self.writeString('', False); self.data.write_u8(AMF0.OBJECT_END)
+            for key, val in data.__dict__.items():
+                if not key.startswith('_'):
+                    self.writeString(key, False)
+                    self.write(val)
+            self.writeString('', False)
+            self.data.write_u8(AMF0.OBJECT_END)
 
-    def readReference(self): 
-        try: return self._obj_refs[self.data.read_u16()]
-        except IndexError: raise ValueError('invalid reference index')
+    def readReference(self):
+        try:
+            return self._obj_refs[self.data.read_u16()]
+        except IndexError:
+            raise ValueError('invalid reference index')
+
     def writePossibleReference(self, data):
-        if data in self._obj_refs: self.data.write_u8(AMF0.REFERENCE); self.data.write_u16(self._obj_refs.index(data)); return True
-        elif len(self._obj_refs) < 0xfffe: self._obj_refs.append(data)
-    
+        if data in self._obj_refs:
+            self.data.write_u8(AMF0.REFERENCE)
+            self.data.write_u16(self._obj_refs.index(data))
+            return True
+        elif len(self._obj_refs) < 0xfffe:
+            self._obj_refs.append(data)
+
     def readEcmaArray(self):
         len_ignored = self.data.read_u32()
         obj, key = self._created(dict()), self.readString()
         while key != '' or self.data.peek() != chr(AMF0.OBJECT_END):
-            obj[int(key) if key.isdigit() else key] = self.read(); key = self.readString()
-        self.data.read(1) # discard OBJECT_END
+            obj[int(key) if key.isdigit() else key] = self.read()
+            key = self.readString()
+        self.data.read(1)  # discard OBJECT_END
         return obj
+
     def writeEcmaArray(self, data):
         if not self.writePossibleReference(data):
-            self.data.write_u8(AMF0.ECMA_ARRAY); self.data.write_u32(len(data))
-            for key, val in data.items(): self.writeString(key, writeType=False); self.write(val)
-            self.writeString('', writeType=False); self.data.write_u8(AMF0.OBJECT_END)
-         
+            self.data.write_u8(AMF0.ECMA_ARRAY)
+            self.data.write_u32(len(data))
+            for key, val in data.items():
+                self.writeString(key, writeType=False)
+                self.write(val)
+            self.writeString('', writeType=False)
+            self.data.write_u8(AMF0.OBJECT_END)
+
     def readArray(self):
         count, obj = self.data.read_u32(), self._created([])
-        obj.extend(self.read() for i in xrange(count)) 
+        obj.extend(self.read() for i in xrange(count))
         return obj
+
     def writeArray(self, data):
         if not self.writePossibleReference(data):
-            self.data.write_u8(AMF0.ARRAY); self.data.write_u32(len(data))
-            for val in data: self.write(val)
-    
+            self.data.write_u8(AMF0.ARRAY)
+            self.data.write_u32(len(data))
+            for val in data:
+                self.write(val)
+
     def readDate(self):
         ms, tz = self.data.read_double(), self.data.read_s16()
+
         class TZ(datetime.tzinfo):
             def utcoffset(self, dt): return datetime.timedelta(minutes=tz)
-            def dst(self,dt): return None
-            def tzname(self,dt): return None
+
+            def dst(self, dt): return None
+
+            def tzname(self, dt): return None
         return datetime.datetime.fromtimestamp(ms/1000.0, TZ())
+
     def writeDate(self, data):
-        if isinstance(data, datetime.date): data = datetime.datetime.combine(data, datetime.time(0))
-        self.data.write_u8(AMF0.DATE); ms = time.mktime(data.timetuple)
-        tz = 0 if not data.tzinfo else (data.tzinfo.utcoffset.days*1440 + data.tzinfo.utcoffset.seconds/60)
-        self.data.write_double(ms); self.data.write_s16(tz)
+        if isinstance(data, datetime.date):
+            data = datetime.datetime.combine(data, datetime.time(0))
+        self.data.write_u8(AMF0.DATE)
+        ms = time.mktime(data.timetuple)
+        tz = 0 if not data.tzinfo else (
+            data.tzinfo.utcoffset.days*1440 + data.tzinfo.utcoffset.seconds/60)
+        self.data.write_double(ms)
+        self.data.write_s16(tz)
 
     def readXML(self): return ET.fromstring(self.readLongString())
+
     def writeXML(self, data):
         data = ET.tostring(data, 'utf8')
-        self.data.write_u8(AMF0.XML); self.data.write_u32(len(data)); self.data.write(data)
-    
-    def readTypedObject(self): 
-        classname = self.readString(); obj = self.readObject(); obj._classname = classname; return obj
+        self.data.write_u8(AMF0.XML)
+        self.data.write_u32(len(data))
+        self.data.write(data)
+
+    def readTypedObject(self):
+        classname = self.readString()
+        obj = self.readObject()
+        obj._classname = classname
+        return obj
+
     def writeTypedObject(self, data):
         if not self.writePossibleReference(data):
             self.data.write_u8(AMF0.TYPED_OBJECT)
             self.data.writeString(data._classname)
-            for key, val in data.__dict__.items(): 
-                if not key.startswith('_'): self.writeString(key, False); self.write(val)
-            self.writeString('', False); self.data.write_u8(AMF0.OBJECT_END)
+            for key, val in data.__dict__.items():
+                if not key.startswith('_'):
+                    self.writeString(key, False)
+                    self.write(val)
+            self.writeString('', False)
+            self.data.write_u8(AMF0.OBJECT_END)
 
-    
+
 class AMF3(object):
-    UNDEFINED, NULL, BOOL_FALSE, BOOL_TRUE, INTEGER, NUMBER, STRING, XML, DATE, ARRAY, OBJECT, XMLSTRING, BYTEARRAY = range(0x0d)
+    UNDEFINED, NULL, BOOL_FALSE, BOOL_TRUE, INTEGER, NUMBER, STRING, XML, DATE, ARRAY, OBJECT, XMLSTRING, BYTEARRAY = range(
+        0x0d)
     ANONYMOUS, TYPED, DYNAMIC, EXTERNALIZABLE = 0x01, 0x02, 0x04, 0x08
-    
+
     def __init__(self, data=None):
         self._obj_refs, self._str_refs, self._class_refs = list(), list(), list()
-        self.data = data if isinstance(data, BytesIO) else BytesIO(data) if data is not None else BytesIO()
+        self.data = data if isinstance(data, BytesIO) else BytesIO(
+            data) if data is not None else BytesIO()
 
     def read(self):
         global undefined
         type = self.data.read_u8()
-        if   type == AMF3.UNDEFINED:  return undefined
-        elif type == AMF3.NULL:       return None
-        elif type == AMF3.BOOL_FALSE: return False
-        elif type == AMF3.BOOL_TRUE:  return True
-        elif type == AMF3.INTEGER:    return self.readInteger()
-        elif type == AMF3.NUMBER:     return self.data.read_double()
-        elif type == AMF3.STRING:     return self.readString()
-        elif type == AMF3.XML:        return self.readXML()
-        elif type == AMF3.DATE:       return self.readDate()
-        elif type == AMF3.ARRAY:      return self.readArray()
-        elif type == AMF3.OBJECT:     return self.readObject()
-        elif type == AMF3.XMLSTRING:  return self.readXMLString()
-        elif type == AMF3.BYTEARRAY:  return self.readByteArray()
-        else: raise ValueError('Invalid AMF3 type 0x%02x at %d' % (type, self.data.tell()-1))
-    
+        if type == AMF3.UNDEFINED:
+            return undefined
+        elif type == AMF3.NULL:
+            return None
+        elif type == AMF3.BOOL_FALSE:
+            return False
+        elif type == AMF3.BOOL_TRUE:
+            return True
+        elif type == AMF3.INTEGER:
+            return self.readInteger()
+        elif type == AMF3.NUMBER:
+            return self.data.read_double()
+        elif type == AMF3.STRING:
+            return self.readString()
+        elif type == AMF3.XML:
+            return self.readXML()
+        elif type == AMF3.DATE:
+            return self.readDate()
+        elif type == AMF3.ARRAY:
+            return self.readArray()
+        elif type == AMF3.OBJECT:
+            return self.readObject()
+        elif type == AMF3.XMLSTRING:
+            return self.readXMLString()
+        elif type == AMF3.BYTEARRAY:
+            return self.readByteArray()
+        else:
+            raise ValueError('Invalid AMF3 type 0x%02x at %d' %
+                             (type, self.data.tell()-1))
+
     def write(self, data):
         global undefined
-        if data is None:              self.data.write_u8(AMF3.NULL)
-        elif data == undefined:       self.data.write_u8(AMF3.UNDEFINED)
-        elif isinstance(data, bool):  self.data.write_u8(AMF3.BOOL_FALSE if data is False else AMF3.BOOL_TRUE)
-        elif isinstance(data, (int, long, float)): self.writeNumber(data)
-        elif isinstance(data, types.StringTypes): self.writeString(data)
-        elif isinstance(data, ET._ElementInterface): self.writeXML(data)
-        elif isinstance(data, (datetime.date, datetime.datetime)): self.writeDate(data)
-        elif isinstance(data, (types.ListType, types.TupleType)): self.writeList(data)
-        elif isinstance(data, types.DictType): self.writeDict(data)
-        elif isinstance(data, (types.InstanceType, Object)): self.writeObject(data)
+        if data is None:
+            self.data.write_u8(AMF3.NULL)
+        elif data == undefined:
+            self.data.write_u8(AMF3.UNDEFINED)
+        elif isinstance(data, bool):
+            self.data.write_u8(
+                AMF3.BOOL_FALSE if data is False else AMF3.BOOL_TRUE)
+        elif isinstance(data, (int, long, float)):
+            self.writeNumber(data)
+        elif isinstance(data, types.StringTypes):
+            self.writeString(data)
+        elif isinstance(data, ET._ElementInterface):
+            self.writeXML(data)
+        elif isinstance(data, (datetime.date, datetime.datetime)):
+            self.writeDate(data)
+        elif isinstance(data, (types.ListType, types.TupleType)):
+            self.writeList(data)
+        elif isinstance(data, types.DictType):
+            self.writeDict(data)
+        elif isinstance(data, (types.InstanceType, Object)):
+            self.writeObject(data)
         # no implicit way to invoke writeXMLString and writeByteArray
-        else: raise ValueError('Invalid AMF3 data %r type %r'%(data, type(data)))
-    
+        else:
+            raise ValueError('Invalid AMF3 data %r type %r' %
+                             (data, type(data)))
+
     def _readLengthRef(self):
         val = self.data.read_u29()
         return (val >> 1, val & 0x01 == 0)
-    
+
     def readInteger(self, signed=True):
         self.data.read_u29() if not signed else self.data.read_s29()
+
     def writeNumber(self, data, writeType=True, type=None):
-        if type is None: type = AMF3.INTEGER if isinstance(data, (int, long)) and -0x10000000 <= data <= 0x0FFFFFFF else AMF3.NUMBER
-        if writeType: self.data.write_u8(type)
-        if type == AMF3.INTEGER: self.data.write_s29(data)
-        else: self.data.write_double(float(data))
-    
+        if type is None:
+            type = AMF3.INTEGER if isinstance(
+                data, (int, long)) and -0x10000000 <= data <= 0x0FFFFFFF else AMF3.NUMBER
+        if writeType:
+            self.data.write_u8(type)
+        if type == AMF3.INTEGER:
+            self.data.write_s29(data)
+        else:
+            self.data.write_double(float(data))
+
     def readString(self, refs=None, decode=True):
         length, is_reference = self._readLengthRef()
-        if refs is None: refs = self._str_refs
-        if is_reference: return refs[length]
-        if length == 0: return ''
+        if refs is None:
+            refs = self._str_refs
+        if is_reference:
+            return refs[length]
+        if length == 0:
+            return ''
         result = self.data.read(length)
         if decode:
-            try: result = unicode(result, 'utf8') # Try decoding as regular utf8 first. TODO: will it always raise exception?
-            except UnicodeDecodeError: result = AMF3._decode_utf8_modified(result)
-        if len(result) > 0: refs.append(result)
+            try:
+                # Try decoding as regular utf8 first. TODO: will it always raise exception?
+                result = unicode(result, 'utf8')
+            except UnicodeDecodeError:
+                result = AMF3._decode_utf8_modified(result)
+        if len(result) > 0:
+            refs.append(result)
         return result
+
     def writeString(self, data, writeType=True, refs=None, encode=True):
-        if writeType: self.data.write_u8(AMF3.STRING)
-        if refs is None: refs = self._str_refs
-        if len(data) == 0: self.data.write_u8(0x01)
+        if writeType:
+            self.data.write_u8(AMF3.STRING)
+        if refs is None:
+            refs = self._str_refs
+        if len(data) == 0:
+            self.data.write_u8(0x01)
         elif not self._writePossibleReference(data, refs):
-            if encode and type(data) is unicode: data = unicode(data).encode('utf8')
+            if encode and type(data) is unicode:
+                data = unicode(data).encode('utf8')
             self.data.write_u29((len(data) << 1) & 0x01)
             self.data.write(data)
-        
+
     def _writePossibleReference(self, data, refs):
-        if data in refs: self.data.write_u29(refs.index(data) << 1); return True
-        elif len(refs) < 0x1ffffffe: refs.append(data)
-    
+        if data in refs:
+            self.data.write_u29(refs.index(data) << 1)
+            return True
+        elif len(refs) < 0x1ffffffe:
+            refs.append(data)
+
     # Ported from http://viewvc.rubyforge.mmmultiworks.com/cgi/viewvc.cgi/trunk/lib/ruva/class.rb
     # Ruby version is Copyright (c) 2006 Ross Bamford (rosco AT roscopeco DOT co DOT uk). The string is first converted to UTF16 BE
     @staticmethod
-    def _decode_utf8_modified(data): # Modified UTF-8 data. See http://en.wikipedia.org/wiki/UTF-8#Java for details
+    # Modified UTF-8 data. See http://en.wikipedia.org/wiki/UTF-8#Java for details
+    def _decode_utf8_modified(data):
         utf16, i, b = [], 0, map(ord, data)
         while i < len(b):
-            c = b[i:i+1] if b[i] & 0x80 == 0 else b[i:i+2] if b[i] & 0xc0 == 0xc0 else b[i:i+3] if b[i] & 0xe0 == 0xe0 else b[i:i+4] if b[i] & 0xf8 == 0xf8 else []
-            if len(c) == 0: raise ValueError('invalid modified utf-8')
-            utf16.append(c[0] if len(c) == 1 else (((c[0] & 0x1f) << 6) | (c[1] & 0x3f)) if len(c) == 2 else (((c[0] & 0x0f) << 12) | ((c[1] & 0x3f) << 6) | (c[2] & 0x3f)) if len(c) == 3 else (((c[0] & 0x07) << 18) | ((c[1] & 0x3f) << 12) | ((c[2] & 0x3f) << 6) | (c[3] & 0x3f)) if len(c) == 4 else -1)
-        for c in utf16: 
-            if c > 0xffff: raise ValueError('does not implement more than 16 bit unicode')
+            c = b[i:i+1] if b[i] & 0x80 == 0 else b[i:i+2] if b[i] & 0xc0 == 0xc0 else b[i:i +
+                                                                                         3] if b[i] & 0xe0 == 0xe0 else b[i:i+4] if b[i] & 0xf8 == 0xf8 else []
+            if len(c) == 0:
+                raise ValueError('invalid modified utf-8')
+            utf16.append(c[0] if len(c) == 1 else (((c[0] & 0x1f) << 6) | (c[1] & 0x3f)) if len(c) == 2 else (((c[0] & 0x0f) << 12) | ((c[1] & 0x3f) << 6) | (
+                c[2] & 0x3f)) if len(c) == 3 else (((c[0] & 0x07) << 18) | ((c[1] & 0x3f) << 12) | ((c[2] & 0x3f) << 6) | (c[3] & 0x3f)) if len(c) == 4 else -1)
+        for c in utf16:
+            if c > 0xffff:
+                raise ValueError('does not implement more than 16 bit unicode')
         return unicode(''.join([chr((c >> 8) & 0xff) + chr(c & 0xff) for c in utf16]), 'utf_16_be')
+
     @staticmethod
     def _encode_utf8_modified(data):
         ch = [ord(i) for i in unicode(data).encode('utf_16_be')]
-        utf16 = [(((ch[i] & 0xff) << 8) + (ch[i+1] & 0xff)) for i in xrange(0, len(ch), 2)]
-        b = [(struct.pack('>B', c) if c <= 0x7f else struct.pack('>BB', 0xc0 | (c >> 6) & 0x1f, 0x80 | c & 0x3f) if c <= 0x7ff else struct.pack('>BBB', 0xe0 | (c >> 12) & 0xf, 0x80 | (c >> 6) & 0x3f, 0x80 | c & 0x3f) if c <= 0xffff else struct.pack('!B', 0xf0 | (c >> 18) & 0x7, 0x80 | (c >> 12) & 0x3f, 0x80 | (c >> 6) & 0x3f, 0x80 | c & 0x3f) if c <= 0x10ffff else None) for c in utf16]
+        utf16 = [(((ch[i] & 0xff) << 8) + (ch[i+1] & 0xff))
+                 for i in xrange(0, len(ch), 2)]
+        b = [(struct.pack('>B', c) if c <= 0x7f else struct.pack('>BB', 0xc0 | (c >> 6) & 0x1f, 0x80 | c & 0x3f) if c <= 0x7ff else struct.pack('>BBB', 0xe0 | (c >> 12) & 0xf, 0x80 | (c >> 6) & 0x3f,
+                                                                                                                                                0x80 | c & 0x3f) if c <= 0xffff else struct.pack('!B', 0xf0 | (c >> 18) & 0x7, 0x80 | (c >> 12) & 0x3f, 0x80 | (c >> 6) & 0x3f, 0x80 | c & 0x3f) if c <= 0x10ffff else None) for c in utf16]
         return ''.join(b)
-        
+
     def readDate(self):
         length, is_reference = self._readLengthRef()
-        if is_reference: return self._obj_refs[length]
+        if is_reference:
+            return self._obj_refs[length]
         ms = self.data.read_double(),
-        ts =  datetime.datetime.fromtimestamp(ms/1000.0)
+        ts = datetime.datetime.fromtimestamp(ms/1000.0)
         self._obj_refs.append(ts)
         return ts
+
     def writeDate(self, data):
         self.data.write_u8(AMF3.DATE)
         if not self._writePossibleReference(data, self._obj_refs):
-            if isinstance(data, datetime.time): raise ValueError('invalid type datetime.time found')
-            if isinstance(data, datetime.date): data = datetime.datetime.combine(data, datetime.time(0))
+            if isinstance(data, datetime.time):
+                raise ValueError('invalid type datetime.time found')
+            if isinstance(data, datetime.date):
+                data = datetime.datetime.combine(data, datetime.time(0))
             ms = time.mktime(data.timetuple)
             self.data.write_u29(0x01)
             self.data.write_double(ms * 1000.0)
-    
+
     def readArray(self):
         length, is_reference = self._readLengthRef()
-        if is_reference: return self._obj_refs[length]
+        if is_reference:
+            return self._obj_refs[length]
         key = self.readString(refs=self._str_refs)
-        if key == '': # return python list since only integer index
+        if key == '':  # return python list since only integer index
             result = [self.read() for i in xrange(length)]
-        else: # return python dict with key, value
+        else:  # return python dict with key, value
             result = {}
-            while key != '': result[key] = self.read(); key = self.readString(refs=self._str_refs)
-            for i in xrange(length): result[i] = self.read()
+            while key != '':
+                result[key] = self.read()
+                key = self.readString(refs=self._str_refs)
+            for i in xrange(length):
+                result[i] = self.read()
         self._obj_refs.append(result)
         return result
+
     def writeList(self, data):
         self.data.write_u8(AMF3.ARRAY)
         if not self._writePossibleReference(data, refs=self._obj_refs):
             self.data.write_u29((len(data) << 1) & 0x01)
-            self.data.write_u8(0x01) # empty key, value
-            for val in data: self.write(val)
+            self.data.write_u8(0x01)  # empty key, value
+            for val in data:
+                self.write(val)
+
     def writeDict(self, data, mixed=True):
-        if '' in data: raise ValueError('dict cannot have empty string keys')
+        if '' in data:
+            raise ValueError('dict cannot have empty string keys')
         self.data.write_u8(AMF3.ARRAY)
         if not self._writePossibleReference(data, refs=self._obj_refs):
             if mixed:
                 keys, int_keys, str_keys = data.keys(), [], []
-                int_keys = sorted([x for x in keys if isinstance(x, (int, long))]) # assume max of 256 values
-                str_keys = [x for x in keys if isinstance(x, types.StringTypes)]
-                if len(int_keys) + len(str_keys) < len(keys): raise ValueError('non-int or str key found in dict')
-                if len(int_keys) <= 0 or int_keys[0] != 0 or int_keys[-1] != len(int_keys) - 1: # not dense
-                    str_keys.extend(int_keys); int_keys[:] = []
+                # assume max of 256 values
+                int_keys = sorted(
+                    [x for x in keys if isinstance(x, (int, long))])
+                str_keys = [x for x in keys if isinstance(
+                    x, types.StringTypes)]
+                if len(int_keys) + len(str_keys) < len(keys):
+                    raise ValueError('non-int or str key found in dict')
+                # not dense
+                if len(int_keys) <= 0 or int_keys[0] != 0 or int_keys[-1] != len(int_keys) - 1:
+                    str_keys.extend(int_keys)
+                    int_keys[:] = []
             else:
                 int_keys, str_keys = [], data.keys()
             self.data.write_u29((len(int_keys) << 1) & 0x01)
-            for key in str_keys: self.writeString(str(key), writeType=False); self.write(data[key])
+            for key in str_keys:
+                self.writeString(str(key), writeType=False)
+                self.write(data[key])
             self.data.write_u8(0x01)
-            for key in int_keys: self.write(data[key])
-            
-    # (U29O-ref | (U29O-traits-ext class-name *(U8)) | U29O-traits-ref  | (U29O-traits class-name *(UTF-8-vr))) 
-    # *(value-type) *(dynamic-member))) 
+            for key in int_keys:
+                self.write(data[key])
+
+    # (U29O-ref | (U29O-traits-ext class-name *(U8)) | U29O-traits-ref  | (U29O-traits class-name *(UTF-8-vr)))
+    # *(value-type) *(dynamic-member)))
     def readObject(self):
         type, is_reference = self._readLengthRef()
-        if is_reference: return self._obj_refs[type]
-        if type & 0x03 == 0x03: raise ValueError('externalizable object is not implemented')
-        elif type & 0x01 == 0: class_ = self._class_refs[type >> 1]
-        elif type & 0x03 == 0x01: # class information
+        if is_reference:
+            return self._obj_refs[type]
+        if type & 0x03 == 0x03:
+            raise ValueError('externalizable object is not implemented')
+        elif type & 0x01 == 0:
+            class_ = self._class_refs[type >> 1]
+        elif type & 0x03 == 0x01:  # class information
             class_ = Class()
             class_.name = self.readString()
             class_.attrs = [self.read() for i in xrange(type >> 3)]
-            if type & 0x04 != 0: class_.encoding |= AMF3.DYNAMIC
-            if not class_.name: class_.encoding |= AMF3.ANONYMOUS
-            if len(class_.attrs) > 0: class_.encoding |= AMF3.TYPED
+            if type & 0x04 != 0:
+                class_.encoding |= AMF3.DYNAMIC
+            if not class_.name:
+                class_.encoding |= AMF3.ANONYMOUS
+            if len(class_.attrs) > 0:
+                class_.encoding |= AMF3.TYPED
             self._class_refs.append(class_)
         obj = Object(_class=class_)
-        for attr in class_.attrs: setattr(obj, attr, self.read())
+        for attr in class_.attrs:
+            setattr(obj, attr, self.read())
         if class_.encoding & AMF3.DYNAMIC:
             attr = self.readString()
-            while attr != '': setattr(obj, attr, self.read()); attr = self.readString()
+            while attr != '':
+                setattr(obj, attr, self.read())
+                attr = self.readString()
         self._obj_refs.append(obj)
         return obj
+
     def writeObject(self, data):
         self.data.write_u8(AMF3.OBJECT)
         if not self._writePossibleReference(data, refs=self._obj_refs):
             if isinstance(data, Object) and hasattr(data, '_class'):
                 class_ = data._class
                 if class_ in self._class_refs:
-                    self.data.write_u29((self._class_refs.index(class_) << 2) | 0x01)
+                    self.data.write_u29(
+                        (self._class_refs.index(class_) << 2) | 0x01)
                 else:
                     is_dynamic = 0x80 if class_.encoding & AMF3.DYNAMIC else 0
-                    attr_len = len(class_.attrs) if hasattr(class_, 'attrs') and class_.attrs else 0
+                    attr_len = len(class_.attrs) if hasattr(
+                        class_, 'attrs') and class_.attrs else 0
                     self.data.write_u29((attr_len << 4) | 0x03 | is_dynamic)
-                    if hasattr(class_, 'name') and class_.name: self.writeString(class_.name, writeType=False)
-                    else: self.data.write_u8(0x01)
-                    for attr in class_.attrs: self.writeString(attr, writeType=False)
+                    if hasattr(class_, 'name') and class_.name:
+                        self.writeString(class_.name, writeType=False)
+                    else:
+                        self.data.write_u8(0x01)
+                    for attr in class_.attrs:
+                        self.writeString(attr, writeType=False)
                     self._class_refs.append(class_)
-                for attr in class_.attrs: self.write(getattr(data, attr))
+                for attr in class_.attrs:
+                    self.write(getattr(data, attr))
                 if class_.encoding & AMF3.DYNAMIC:
                     for key, value in data.__dict__.items():
                         if key not in class_.attrs:
                             self.writeString(key, writeType=False)
                             self.write(getattr(data, key))
                     self.data.write_u8(0x01)
-            else: # encode as anonymous and dynamic object.
-                self.data.write_u29(0x0b) # no typed attr, dynamic, class def
+            else:  # encode as anonymous and dynamic object.
+                self.data.write_u29(0x0b)  # no typed attr, dynamic, class def
                 self.data.write_u8(0x01)  # anonymous
                 for key, value in data.__dict__.items():
                     self.writeString(key, writeType=False)
-                    self.write(getattr(data, key)) 
-                self.data.write_u8(0x01) 
-    
-    
+                    self.write(getattr(data, key))
+                self.data.write_u8(0x01)
+
     def readXML(self):
         return ET.fromstring(self.readString(refs=self._obj_refs))
+
     def writeXML(self, data):
         self.data.write_u8(AMF3.XML)
-        self.writeString(ET.tostring(data, 'utf8'), writeType=False, refs=self._obj_refs)
+        self.writeString(ET.tostring(data, 'utf8'),
+                         writeType=False, refs=self._obj_refs)
     # following variants return str or take data as str
+
     def readXMLString(self):
         return self.readString(refs=self._obj_refs)
-    def writeXMLString(self, data): # not implicitly invoked by write()
+
+    def writeXMLString(self, data):  # not implicitly invoked by write()
         self.data.write_u8(AMF3.XMLSTRING)
         self.writeString(data, writeType=False, refs=self._obj_refs)
-    
+
     def readByteArray(self):
         return self.readString(refs=self._obj_refs, decode=False)
-    def writeByteArray(self, data): # not implicitly invoked by write()
+
+    def writeByteArray(self, data):  # not implicitly invoked by write()
         self.data.write_u8(AMF3.BYTEARRAY)
-        self.writeString(data, writeType=False, refs=self._obj_refs, encode=False)
+        self.writeString(data, writeType=False,
+                         refs=self._obj_refs, encode=False)
 
 # Original source was from rtmpy.org's amf.py, util.py with following Copyright.
 # The source in this file has been re-written based on Adobe's AMF0/AMF3 spec.
 #
 # Copyright (c) 2007 The RTMPy Project. All rights reserved.
-# 
+#
 # Arnar Birgisson
 # Thijs Triemstra
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
 # "Software"), to deal in the Software without restriction, including
@@ -429,10 +657,10 @@ class AMF3(object):
 # distribute, sublicense, and/or sell copies of the Software, and to
 # permit persons to whom the Software is furnished to do so, subject to
 # the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND

--- a/tests/rtmplite/multitask.py
+++ b/tests/rtmplite/multitask.py
@@ -1,4 +1,4 @@
-################################################################################
+##########################################################################
 #
 # Copyright (c) 2007 Christopher J. Stawarz
 #
@@ -22,7 +22,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-################################################################################
+##########################################################################
 
 
 """
@@ -55,7 +55,7 @@ two unrelated tasks to run concurrently:
   ...     while True:
   ...         print message
   ...         yield
-  ... 
+  ...
   >>> multitask.add(printer('hello'))
   >>> multitask.add(printer('goodbye'))
   >>> multitask.run()
@@ -102,26 +102,26 @@ raised within a child task is propagated to its parent.  For example:
   ...         yield raise_exception()
   ...     except Exception, e:
   ...         print 'caught exception: %s' % e
-  ... 
+  ...
   >>> def return_none():
   ...     yield
   ...     # do nothing
   ...     # or return
   ...     # or raise StopIteration
   ...     # or raise StopIteration(None)
-  ... 
+  ...
   >>> def return_one():
   ...     yield
   ...     raise StopIteration(1)
-  ... 
+  ...
   >>> def return_many():
   ...     yield
   ...     raise StopIteration(2, 3)  # or raise StopIteration((2, 3))
-  ... 
+  ...
   >>> def raise_exception():
   ...     yield
   ...     raise RuntimeError('foo')
-  ... 
+  ...
   >>> multitask.add(parent())
   >>> multitask.run()
   None
@@ -148,11 +148,11 @@ __version__ = '0.2.0'
 # __revision__ = int('$Revision$'.split()[1])
 
 
-################################################################################
+##########################################################################
 #
 # Timeout exception type
 #
-################################################################################
+##########################################################################
 
 
 class Timeout(Exception):
@@ -160,11 +160,11 @@ class Timeout(Exception):
     pass
 
 
-################################################################################
+##########################################################################
 #
 # _ChildTask class
 #
-################################################################################
+##########################################################################
 
 
 class _ChildTask(object):
@@ -180,11 +180,11 @@ class _ChildTask(object):
         return self.task.throw(type, value, traceback)
 
 
-################################################################################
+##########################################################################
 #
 # YieldCondition class
 #
-################################################################################
+##########################################################################
 
 
 class YieldCondition(object):
@@ -220,11 +220,11 @@ class YieldCondition(object):
         return (self.expiration is not None)
 
 
-################################################################################
+##########################################################################
 #
 # _SleepDelay class and related functions
 #
-################################################################################
+##########################################################################
 
 
 class _SleepDelay(YieldCondition):
@@ -251,11 +251,11 @@ def sleep(seconds):
     return _SleepDelay(seconds)
 
 
-################################################################################
+##########################################################################
 #
 # FDReady class and related functions
 #
-################################################################################
+##########################################################################
 
 
 class FDReady(YieldCondition):
@@ -351,11 +351,11 @@ def writable(fd, timeout=None):
     return FDReady(fd, write=True, timeout=timeout)
 
 
-################################################################################
+##########################################################################
 #
 # FDAction class and related functions
 #
-################################################################################
+##########################################################################
 
 
 class FDAction(FDReady):
@@ -573,11 +573,11 @@ def sendto(sock, *args, **kwargs):
     return FDAction(sock, sock.sendto, args, kwargs, write=True)
 
 
-################################################################################
+##########################################################################
 #
 # Queue and _QueueAction classes
 #
-################################################################################
+##########################################################################
 
 
 class Queue(object):
@@ -671,11 +671,11 @@ class _QueueAction(YieldCondition):
         self.item = item
 
 
-################################################################################
+##########################################################################
 #
 # SmartQueue and _SmartQueueAction classes
 #
-################################################################################
+##########################################################################
 
 
 class SmartQueue(object):
@@ -685,7 +685,7 @@ class SmartQueue(object):
     A multi-producer, multi-consumer FIFO queue (similar to
     Queue.Queue) that can be used for exchanging data between tasks.
     The difference with Queue is that this implements filtering criteria
-    on get and allows multiple get to be signalled for the same put. 
+    on get and allows multiple get to be signalled for the same put.
     On the downside, this uses list instead of deque and has lower
     performance.
 
@@ -710,7 +710,8 @@ class SmartQueue(object):
         return len(self._pending)
 
     def _get(self, criteria=None):
-        # self._pending = filter(lambda x: x[1]<=now, self._pending) # remove expired ones
+        # self._pending = filter(lambda x: x[1]<=now, self._pending) # remove
+        # expired ones
         if criteria:
             # check any matching criteria
             found = filter(lambda x: criteria(x), self._pending)
@@ -760,9 +761,9 @@ class SmartQueue(object):
         when item has been added to the queue.  If timeout is not
         None, a Timeout exception will be raised in the yielding task
         if no space is available after timeout seconds have elapsed.
-        TODO: Otherwise if space is available, the timeout specifies how 
+        TODO: Otherwise if space is available, the timeout specifies how
         long to keep the item in the queue before discarding it if it
-        is not fetched in a get. In this case it doesnot throw exception. 
+        is not fetched in a get. In this case it doesnot throw exception.
         For example:
 
           try:
@@ -789,11 +790,11 @@ class _SmartQueueAction(YieldCondition):
         self.expires = (timeout is not None) and (time.time() + timeout) or 0
 
 
-################################################################################
+##########################################################################
 #
 # TaskManager class
 #
-################################################################################
+##########################################################################
 
 
 class TaskManager(object):
@@ -932,7 +933,8 @@ class TaskManager(object):
         """
 
         while self.has_io_waits():
-            if self._handle_io_waits(self._fix_run_timeout(timeout)) or self.has_runnable():
+            if self._handle_io_waits(self._fix_run_timeout(
+                    timeout)) or self.has_runnable():
                 break
 
         if self.has_timeouts():
@@ -947,7 +949,7 @@ class TaskManager(object):
                     output = task.throw(*exc_info)
                 else:
                     output = task.send(input)
-            except StopIteration, e:
+            except StopIteration as e:
                 if isinstance(task, _ChildTask):
                     if not e.args:
                         output = None
@@ -956,7 +958,7 @@ class TaskManager(object):
                     else:
                         output = e.args
                     self._enqueue(task.parent, input=output)
-            except:
+            except BaseException:
                 if isinstance(task, _ChildTask):
                     # Propagate exception to parent
                     self._enqueue(task.parent, exc_info=sys.exc_info())
@@ -988,7 +990,7 @@ class TaskManager(object):
         except (TypeError, ValueError):
             self._remove_bad_file_descriptors()
             return False
-        except (select.error, IOError), err:
+        except (select.error, IOError) as err:
             if err[0] == errno.EINTR:
                 return False
             elif ((err[0] == errno.EBADF) or
@@ -1004,7 +1006,7 @@ class TaskManager(object):
                 try:
                     input = (fd._eval() if isinstance(fd, FDAction) else None)
                     self._enqueue(fd.task, input=input)
-                except:
+                except BaseException:
                     self._enqueue(fd.task, exc_info=sys.exc_info())
                 fd._remove_from_fdsets(self._read_waits,
                                        self._write_waits,
@@ -1017,7 +1019,7 @@ class TaskManager(object):
         for fd in (self._read_waits | self._write_waits | self._exc_waits):
             try:
                 select.select([fd], [fd], [fd], 0.0)
-            except:
+            except BaseException:
                 # TODO: do not enqueue the exception (socket.error) so that it does not crash
                 # when closing an already closed socket. See rtmplite issue #28
                 # self._enqueue(fd.task, exc_info=sys.exc_info())
@@ -1156,11 +1158,11 @@ class TaskManager(object):
                             self._remove_timeout(action)
 
 
-################################################################################
+##########################################################################
 #
 # Default TaskManager instance
 #
-################################################################################
+##########################################################################
 
 
 _default_task_manager = None
@@ -1184,11 +1186,11 @@ def run():
     get_default_task_manager().run()
 
 
-################################################################################
+##########################################################################
 #
 # Test routine
 #
-################################################################################
+##########################################################################
 
 
 if __name__ == '__main__':
@@ -1222,7 +1224,7 @@ if __name__ == '__main__':
         print 'bad_descriptor running'
         try:
             yield readable(12)
-        except:
+        except BaseException:
             print 'exception in bad_descriptor:', sys.exc_info()[1]
 
     def sleeper():
@@ -1248,7 +1250,7 @@ if __name__ == '__main__':
         print 'child returned: %s' % ((yield child()),)
         try:
             yield child(raise_exc=True)
-        except:
+        except BaseException:
             print 'exception in child:', sys.exc_info()[1]
 
     def child(raise_exc=False):

--- a/tests/rtmplite/multitask.py
+++ b/tests/rtmplite/multitask.py
@@ -25,7 +25,6 @@
 ################################################################################
 
 
-
 """
 
 Cooperative multitasking and asynchronous I/O using generators
@@ -144,10 +143,9 @@ import time
 import types
 
 
-__author__   = 'Christopher Stawarz <cstawarz@csail.mit.edu>'
-__version__  = '0.2.0'
+__author__ = 'Christopher Stawarz <cstawarz@csail.mit.edu>'
+__version__ = '0.2.0'
 # __revision__ = int('$Revision$'.split()[1])
-
 
 
 ################################################################################
@@ -157,11 +155,9 @@ __version__  = '0.2.0'
 ################################################################################
 
 
-
 class Timeout(Exception):
     'Raised in a yielding task when an operation times out'
     pass
-
 
 
 ################################################################################
@@ -169,7 +165,6 @@ class Timeout(Exception):
 # _ChildTask class
 #
 ################################################################################
-
 
 
 class _ChildTask(object):
@@ -185,13 +180,11 @@ class _ChildTask(object):
         return self.task.throw(type, value, traceback)
 
 
-
 ################################################################################
 #
 # YieldCondition class
 #
 ################################################################################
-
 
 
 class YieldCondition(object):
@@ -227,13 +220,11 @@ class YieldCondition(object):
         return (self.expiration is not None)
 
 
-
 ################################################################################
 #
 # _SleepDelay class and related functions
 #
 ################################################################################
-
 
 
 class _SleepDelay(YieldCondition):
@@ -260,13 +251,11 @@ def sleep(seconds):
     return _SleepDelay(seconds)
 
 
-
 ################################################################################
 #
 # FDReady class and related functions
 #
 ################################################################################
-
 
 
 class FDReady(YieldCondition):
@@ -362,13 +351,11 @@ def writable(fd, timeout=None):
     return FDReady(fd, write=True, timeout=timeout)
 
 
-
 ################################################################################
 #
 # FDAction class and related functions
 #
 ################################################################################
-
 
 
 class FDAction(FDReady):
@@ -586,13 +573,11 @@ def sendto(sock, *args, **kwargs):
     return FDAction(sock, sock.sendto, args, kwargs, write=True)
 
 
-
 ################################################################################
 #
 # Queue and _QueueAction classes
 #
 ################################################################################
-
 
 
 class Queue(object):
@@ -693,7 +678,6 @@ class _QueueAction(YieldCondition):
 ################################################################################
 
 
-
 class SmartQueue(object):
 
     """
@@ -704,7 +688,7 @@ class SmartQueue(object):
     on get and allows multiple get to be signalled for the same put. 
     On the downside, this uses list instead of deque and has lower
     performance.
-    
+
     """
 
     def __init__(self, contents=(), maxsize=0):
@@ -719,17 +703,18 @@ class SmartQueue(object):
         """
 
         self.maxsize = int(maxsize)
-        self._pending =  list(contents)
+        self._pending = list(contents)
 
     def __len__(self):
         'Return the number of items in the queue'
         return len(self._pending)
 
     def _get(self, criteria=None):
-        #self._pending = filter(lambda x: x[1]<=now, self._pending) # remove expired ones
+        # self._pending = filter(lambda x: x[1]<=now, self._pending) # remove expired ones
         if criteria:
-            found = filter(lambda x: criteria(x), self._pending)   # check any matching criteria
-            if found: 
+            # check any matching criteria
+            found = filter(lambda x: criteria(x), self._pending)
+            if found:
                 self._pending.remove(found[0])
                 return found[0]
             else:
@@ -811,7 +796,6 @@ class _SmartQueueAction(YieldCondition):
 ################################################################################
 
 
-
 class TaskManager(object):
 
     """
@@ -831,12 +815,12 @@ class TaskManager(object):
 
         """
 
-        self._queue       = collections.deque()
-        self._read_waits  = set()
+        self._queue = collections.deque()
+        self._read_waits = set()
         self._write_waits = set()
-        self._exc_waits   = set()
+        self._exc_waits = set()
         self._queue_waits = collections.defaultdict(self._double_deque)
-        self._timeouts    = []
+        self._timeouts = []
 
     @staticmethod
     def _double_deque():
@@ -856,9 +840,9 @@ class TaskManager(object):
 
         # Merge the data structures
         self._queue.extend(other._queue)
-        self._read_waits  |= other._read_waits
+        self._read_waits |= other._read_waits
         self._write_waits |= other._write_waits
-        self._exc_waits   |= other._exc_waits
+        self._exc_waits |= other._exc_waits
         self._queue_waits.update(other._queue_waits)
         self._timeouts.extend(other._timeouts)
         heapq.heapify(self._timeouts)
@@ -866,12 +850,12 @@ class TaskManager(object):
         # Make other reference the merged data structures.  This is
         # necessary because other's tasks may reference and use other
         # (e.g. to add a new task in response to an event).
-        other._queue       = self._queue
-        other._read_waits  = self._read_waits
+        other._queue = self._queue
+        other._read_waits = self._read_waits
         other._write_waits = self._write_waits
-        other._exc_waits   = self._exc_waits
+        other._exc_waits = self._exc_waits
         other._queue_waits = self._queue_waits
-        other._timeouts    = self._timeouts
+        other._timeouts = self._timeouts
 
     def add(self, task):
         'Add a new task (i.e. a generator instance) to the run queue'
@@ -948,13 +932,14 @@ class TaskManager(object):
         """
 
         while self.has_io_waits():
-            if self._handle_io_waits(self._fix_run_timeout(timeout)) or self.has_runnable(): break
+            if self._handle_io_waits(self._fix_run_timeout(timeout)) or self.has_runnable():
+                break
 
         if self.has_timeouts():
             self._handle_timeouts(self._fix_run_timeout(timeout))
 
         # Run all tasks currently in the queue
-        #for dummy in xrange(len(self._queue)):
+        # for dummy in xrange(len(self._queue)):
         while len(self._queue) > 0:
             task, input, exc_info = self._queue.popleft()
             try:
@@ -1129,7 +1114,6 @@ class TaskManager(object):
                     if action._expires():
                         self._remove_timeout(action)
 
-
     def _handle_smart_queue_action(self, task, output):
         get_waits, put_waits = self._queue_waits[output.queue]
 
@@ -1165,12 +1149,11 @@ class TaskManager(object):
                         item = output.queue._get(criteria=action.criteria)
                         if item is not None:
                             actions.append((action, item))
-                    for action,item in actions:
+                    for action, item in actions:
                         get_waits.remove(action)
                         self._enqueue(action.task, input=item)
                         if action._expires():
                             self._remove_timeout(action)
-
 
 
 ################################################################################
@@ -1178,7 +1161,6 @@ class TaskManager(object):
 # Default TaskManager instance
 #
 ################################################################################
-
 
 
 _default_task_manager = None
@@ -1202,13 +1184,11 @@ def run():
     get_default_task_manager().run()
 
 
-
 ################################################################################
 #
 # Test routine
 #
 ################################################################################
-
 
 
 if __name__ == '__main__':

--- a/tests/rtmplite/rtmp.py
+++ b/tests/rtmplite/rtmp.py
@@ -81,7 +81,8 @@ class ConnectionClosed:
 
 
 def truncate(data, max=100):
-    return data and len(data) > max and data[:max] + '...(%d)' % (len(data),) or data
+    return data and len(
+        data) > max and data[:max] + '...(%d)' % (len(data),) or data
 
 
 class SockStream(object):
@@ -112,7 +113,7 @@ class SockStream(object):
                 self.buffer += data
         except StopIteration:
             raise
-        except:
+        except BaseException:
             # anything else is treated as connection closed.
             raise ConnectionClosed
 
@@ -127,7 +128,7 @@ class SockStream(object):
                 print 'socket.write[%d] %r' % (len(chunk), truncate(chunk))
             try:
                 yield multitask.send(self.sock, chunk)
-            except:
+            except BaseException:
                 raise ConnectionClosed
 
 
@@ -147,7 +148,7 @@ This are the formats of the basic header:
 
  0 1 2 3 4 5 6 7      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
 +-+-+-+-+-+-+-+-+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|fmt|   cs id   |    |fmt|     0     |   cs id - 64  |    |fmt|     1     |        cs id - 64             | 
+|fmt|   cs id   |    |fmt|     0     |   cs id - 64  |    |fmt|     1     |        cs id - 64             |
 +-+-+-+-+-+-+-+-+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
   (cs id < 64)            (64 <= cs id < 320)                           (320 <= cs id)
@@ -160,7 +161,7 @@ Type 0 (fmt=00):
 
 This type MUST be used at the start of a chunk stream, and whenever the stream timestamp goes backward (e.g., because of a backward seek).
 
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                      timestamp                |                message length                 |message type id|                message stream id              |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -171,7 +172,7 @@ Type 1 (fmt=01):
 
 Streams with variable-sized messages (for example, many video formats) SHOULD use this format for the first chunk of each new message after the first.
 
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5  
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                timestamp delta                |                message length                 |message type id|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -180,9 +181,9 @@ Streams with variable-sized messages (for example, many video formats) SHOULD us
 Type 2 (fmt=10):
 ----------------
 
-Streams with constant-sized messages (for example, some audio and data formats) SHOULD use this format for the first chunk of each message after the first. 
+Streams with constant-sized messages (for example, some audio and data formats) SHOULD use this format for the first chunk of each message after the first.
 
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3   
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                timestamp delta                |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -197,10 +198,10 @@ the preceding chunk. When a single message is split into chunks, all chunks of a
 Extended Timestamp:
 -------------------
 
-This field is transmitted only when the normal time stamp in the chunk message header is set to 0x00ffffff. If normal time stamp is 
-set to any value less than 0x00ffffff, this field MUST NOT be present. This field MUST NOT be present if the timestamp field is not 
+This field is transmitted only when the normal time stamp in the chunk message header is set to 0x00ffffff. If normal time stamp is
+set to any value less than 0x00ffffff, this field MUST NOT be present. This field MUST NOT be present if the timestamp field is not
 present. Type 3 chunks MUST NOT have this field. This field if transmitted is located immediately after the chunk message header
-and before the chunk data. 
+and before the chunk data.
 
 '''
 
@@ -223,9 +224,9 @@ class Header(object):
         if (channel < 64):
             self.hdrdata = struct.pack('>B', channel)
         elif (channel < 320):
-            self.hdrdata = '\x00' + struct.pack('>B', channel-64)
+            self.hdrdata = '\x00' + struct.pack('>B', channel - 64)
         else:
-            self.hdrdata = '\x01' + struct.pack('>H', channel-64)
+            self.hdrdata = '\x01' + struct.pack('>H', channel - 64)
 
     def toBytes(self, control):
         data = chr(ord(self.hdrdata[0]) | control)
@@ -244,7 +245,8 @@ class Header(object):
                 if control != Header.MESSAGE:
                     # add streamId in little-endian 4 bytes
                     data += struct.pack('<I', self.streamId)
-            # add the extended time part to the header if timestamp[delta] >= 16777215
+            # add the extended time part to the header if timestamp[delta] >=
+            # 16777215
             if self.time >= 0xFFFFFF:
                 data += struct.pack('>I', self.time)
         return data
@@ -254,19 +256,23 @@ class Header(object):
                 % (self.channel, self.time, self.size, Message.type_name.get(self.type, 'unknown'), self.type, self.streamId))
 
     def dup(self):
-        return Header(channel=self.channel, time=self.time, size=self.size, type=self.type, streamId=self.streamId)
+        return Header(channel=self.channel, time=self.time,
+                      size=self.size, type=self.type, streamId=self.streamId)
 
 
 class Message(object):
     # message types: RPC3, DATA3,and SHAREDOBJECT3 are used with AMF3
-    CHUNK_SIZE,   ABORT,   ACK,   USER_CONTROL, WIN_ACK_SIZE, SET_PEER_BW, AUDIO, VIDEO, DATA3, SHAREDOBJ3, RPC3, DATA, SHAREDOBJ, RPC, AGGREGATE = \
-        0x01,         0x02,    0x03,  0x04,         0x05,         0x06,        0x08,  0x09,  0x0F,  0x10,       0x11, 0x12, 0x13,      0x14, 0x16
-    type_name = dict(enumerate('unknown chunk-size abort ack user-control win-ack-size set-peer-bw unknown audio video unknown unknown unknown unknown unknown data3 sharedobj3 rpc3 data sharedobj rpc unknown aggregate'.split()))
+    CHUNK_SIZE, ABORT, ACK, USER_CONTROL, WIN_ACK_SIZE, SET_PEER_BW, AUDIO, VIDEO, DATA3, SHAREDOBJ3, RPC3, DATA, SHAREDOBJ, RPC, AGGREGATE = \
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x08, 0x09, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x16
+    type_name = dict(
+        enumerate(
+            'unknown chunk-size abort ack user-control win-ack-size set-peer-bw unknown audio video unknown unknown unknown unknown unknown data3 sharedobj3 rpc3 data sharedobj rpc unknown aggregate'.split()))
 
     def __init__(self, hdr=None, data=''):
         self.header, self.data = hdr or Header(), data
 
-    # define properties type, streamId and time to access self.header.(property)
+    # define properties type, streamId and time to access
+    # self.header.(property)
     for p in ['type', 'streamId', 'time']:
         exec 'def _g%s(self): return self.header.%s' % (p, p)
         exec 'def _s%s(self, %s): self.header.%s = %s' % (p, p, p, p)
@@ -276,7 +282,8 @@ class Message(object):
     def size(self): return len(self.data)
 
     def __repr__(self):
-        return ("<Message header=%r data=%r>" % (self.header, truncate(self.data)))
+        return ("<Message header=%r data=%r>" %
+                (self.header, truncate(self.data)))
 
     def dup(self):
         return Message(self.header.dup(), self.data[:])
@@ -284,20 +291,20 @@ class Message(object):
 
 class Protocol(object):
     PING_SIZE, DEFAULT_CHUNK_SIZE, HIGH_WRITE_CHUNK_SIZE, PROTOCOL_CHANNEL_ID = 1536, 128, 4096, 2  # constants
-    READ_WIN_SIZE, WRITE_WIN_SIZE = 1000000L, 1073741824L
+    READ_WIN_SIZE, WRITE_WIN_SIZE = 1000000, 1073741824
 
     def __init__(self, sock):
         self.stream = SockStream(sock)
         self.lastReadHeaders, self.incompletePackets, self.lastWriteHeaders = dict(), dict(), dict()
         self.readChunkSize = self.writeChunkSize = Protocol.DEFAULT_CHUNK_SIZE
-        self.readWinSize0, self.readWinSize, self.writeWinSize0, self.writeWinSize = 0L, self.READ_WIN_SIZE, 0L, self.WRITE_WIN_SIZE
+        self.readWinSize0, self.readWinSize, self.writeWinSize0, self.writeWinSize = 0, self.READ_WIN_SIZE, 0, self.WRITE_WIN_SIZE
         self.nextChannelId = Protocol.PROTOCOL_CHANNEL_ID + 1
         self._time0 = time.time()
         self.writeQueue = multitask.Queue()
 
     @property
     def relativeTime(self):
-        return int(1000*(time.time() - self._time0))
+        return int(1000 * (time.time() - self._time0))
 
     def messageReceived(self, msg):  # override in subclass
         yield
@@ -337,7 +344,7 @@ class Protocol(object):
             yield self.connectionClosed()
             if _debug:
                 print 'parse connection closed'
-        except:
+        except BaseException:
             if _debug:
                 print 'exception, closing connection'
             if _debug:
@@ -375,9 +382,10 @@ class Protocol(object):
 
     @staticmethod
     def handshakeResponse(data):
-        # send both data parts before reading next ping-size, to work with ffmpeg
+        # send both data parts before reading next ping-size, to work with
+        # ffmpeg
         if struct.unpack('>I', data[5:9])[0] == 0:
-            data = '\x03' + '\x00'*Protocol.PING_SIZE
+            data = '\x03' + '\x00' * Protocol.PING_SIZE
             return data + data[1:]
         else:
             type, data = ord(data[0]), data[1:]  # first byte is ignored
@@ -386,10 +394,10 @@ class Protocol(object):
                 digest_offset = (sum([ord(data[i]) for i in range(
                     772, 776)]) % 728 + 776) if s == 1 else (sum([ord(data[i]) for i in range(8, 12)]) % 728 + 12)
                 temp = data[0:digest_offset] + \
-                    data[digest_offset+32:Protocol.PING_SIZE]
+                    data[digest_offset + 32:Protocol.PING_SIZE]
                 hash = Protocol._calculateHash(
                     temp, Protocol.FLASHPLAYER_KEY[:30])
-                if hash == data[digest_offset:digest_offset+32]:
+                if hash == data[digest_offset:digest_offset + 32]:
                     scheme = s
                     break
             if scheme is None:
@@ -398,31 +406,31 @@ class Protocol(object):
                 scheme = 0
             client_dh_offset = (sum([ord(data[i]) for i in range(768, 772)]) % 632 + 8) if scheme == 1 else (
                 sum([ord(data[i]) for i in range(1532, 1536)]) % 632 + 772)
-            outgoingKp = data[client_dh_offset:client_dh_offset+128]
+            outgoingKp = data[client_dh_offset:client_dh_offset + 128]
             handshake = struct.pack('>IBBBB', 0, 1, 2, 3, 4) + ''.join(
-                [chr(random.randint(0, 255)) for i in xrange(Protocol.PING_SIZE-8)])
+                [chr(random.randint(0, 255)) for i in xrange(Protocol.PING_SIZE - 8)])
             server_dh_offset = (sum([ord(handshake[i]) for i in range(768, 772)]) % 632 + 8) if scheme == 1 else (
                 sum([ord(handshake[i]) for i in range(1532, 1536)]) % 632 + 772)
             keys = Protocol._generateKeyPair()  # (public, private)
             handshake = handshake[:server_dh_offset] + \
-                keys[0][0:128] + handshake[server_dh_offset+128:]
+                keys[0][0:128] + handshake[server_dh_offset + 128:]
             if type > 0x03:
                 raise Exception('encryption is not supported')
             server_digest_offset = (sum([ord(handshake[i]) for i in range(
                 772, 776)]) % 728 + 776) if scheme == 1 else (sum([ord(handshake[i]) for i in range(8, 12)]) % 728 + 12)
             temp = handshake[0:server_digest_offset] + \
-                handshake[server_digest_offset+32:Protocol.PING_SIZE]
+                handshake[server_digest_offset + 32:Protocol.PING_SIZE]
             hash = Protocol._calculateHash(temp, Protocol.SERVER_KEY[:36])
             handshake = handshake[:server_digest_offset] + \
-                hash + handshake[server_digest_offset+32:]
-            buffer = data[:Protocol.PING_SIZE-32]
+                hash + handshake[server_digest_offset + 32:]
+            buffer = data[:Protocol.PING_SIZE - 32]
             key_challenge_offset = (sum([ord(buffer[i]) for i in range(
                 772, 776)]) % 728 + 776) if scheme == 1 else (sum([ord(buffer[i]) for i in range(8, 12)]) % 728 + 12)
-            challenge_key = data[key_challenge_offset:key_challenge_offset+32]
+            challenge_key = data[key_challenge_offset:key_challenge_offset + 32]
             hash = Protocol._calculateHash(
                 challenge_key, Protocol.SERVER_KEY[:68])
             rand_bytes = ''.join([chr(random.randint(0, 255))
-                                  for i in xrange(Protocol.PING_SIZE-32)])
+                                  for i in xrange(Protocol.PING_SIZE - 32)])
             last_hash = Protocol._calculateHash(rand_bytes, hash[:32])
             output = chr(type) + handshake + rand_bytes + last_hash
             return output
@@ -433,7 +441,8 @@ class Protocol(object):
 
     @staticmethod
     def _generateKeyPair():  # dummy key pair since we don't support encryption
-        return (''.join([chr(random.randint(0, 255)) for i in xrange(128)]), '')
+        return (''.join([chr(random.randint(0, 255))
+                         for i in xrange(128)]), '')
 
     def parseMessages(self):
         '''Parses complete messages until connection closed. Raises ConnectionLost exception.'''
@@ -449,7 +458,7 @@ class Protocol(object):
                 channel = 64 + ord(data[0]) + 256 * ord(data[1])
 
             hdrtype = hdrsize & Header.MASK   # read header type byte
-            if hdrtype == Header.FULL or not self.lastReadHeaders.has_key(channel):
+            if hdrtype == Header.FULL or channel not in self.lastReadHeaders:
                 header = Header(channel)
                 self.lastReadHeaders[channel] = header
             else:
@@ -482,9 +491,11 @@ class Protocol(object):
             elif hdrtype in (Header.MESSAGE, Header.TIME):
                 header.hdrtype = hdrtype
 
-            # print header.type, '0x%02x'%(hdrtype,), header.time, header.currentTime
+            # print header.type, '0x%02x'%(hdrtype,), header.time,
+            # header.currentTime
 
-            # if _debug: print 'R', header, header.currentTime, header.extendedTime, '0x%x'%(hdrsize,)
+            # if _debug: print 'R', header, header.currentTime,
+            # header.extendedTime, '0x%x'%(hdrsize,)
 
             # are we continuing an incomplete packet?
             data = self.incompletePackets.get(channel, "")
@@ -496,7 +507,8 @@ class Protocol(object):
 
             # check if we need to send Ack
             if self.readWinSize is not None:
-                if self.stream.bytesRead > (self.readWinSize0 + self.readWinSize):
+                if self.stream.bytesRead > (
+                        self.readWinSize0 + self.readWinSize):
                     self.readWinSize0 = self.stream.bytesRead
                     ack = Message()
                     ack.time, ack.type, ack.data = self.relativeTime, Message.ACK, struct.pack(
@@ -571,7 +583,7 @@ class Protocol(object):
                 yield self.protocolMessage(msg)
             else:
                 yield self.messageReceived(msg)
-        except:
+        except BaseException:
             if _debug:
                 print 'Protocol.parseMessage exception', (traceback and traceback.print_exc() or None)
 
@@ -580,7 +592,8 @@ class Protocol(object):
         while True:
             #            while self.writeQueue.empty(): (yield multitask.sleep(0.01))
             #            message = self.writeQueue.get() # TODO this should be used using multitask.Queue and remove previous wait.
-            # TODO this should be used using multitask.Queue and remove previous wait.
+            # TODO this should be used using multitask.Queue and remove
+            # previous wait.
             message = yield self.writeQueue.get()
             if _debug:
                 print 'Protocol.write msg=', message
@@ -588,16 +601,16 @@ class Protocol(object):
                 try:
                     # just in case TCP socket is not closed, close it.
                     self.stream.close()
-                except:
+                except BaseException:
                     pass
                 break
 
             # get the header stored for the stream
-            if self.lastWriteHeaders.has_key(message.streamId):
+            if message.streamId in self.lastWriteHeaders:
                 header = self.lastWriteHeaders[message.streamId]
             else:
                 if self.nextChannelId <= Protocol.PROTOCOL_CHANNEL_ID:
-                    self.nextChannelId = Protocol.PROTOCOL_CHANNEL_ID+1
+                    self.nextChannelId = Protocol.PROTOCOL_CHANNEL_ID + 1
                 header, self.nextChannelId = Header(
                     self.nextChannelId), self.nextChannelId + 1
                 self.lastWriteHeaders[message.streamId] = header
@@ -609,10 +622,10 @@ class Protocol(object):
                 header.streamId, header.type, header.size, header.time, header.delta = message.streamId, message.type, message.size, message.time, message.time
                 control = Header.FULL
             elif header.size != message.size or header.type != message.type:
-                header.type, header.size, header.time, header.delta = message.type, message.size, message.time, message.time-header.time
+                header.type, header.size, header.time, header.delta = message.type, message.size, message.time, message.time - header.time
                 control = Header.MESSAGE
             else:
-                header.time, header.delta = message.time, message.time-header.time
+                header.time, header.delta = message.time, message.time - header.time
                 control = Header.TIME
 
             hdr = Header(channel=header.channel, time=header.delta if control in (
@@ -630,20 +643,22 @@ class Protocol(object):
                 yield self.stream.write(data)
             except ConnectionClosed:
                 yield self.connectionClosed()
-            except:
+            except BaseException:
                 print traceback.print_exc()
 
 
 class Command(object):
     ''' Class for command / data messages'''
 
-    def __init__(self, type=Message.RPC, name=None, id=None, tm=0, cmdData=None, args=[]):
+    def __init__(self, type=Message.RPC, name=None,
+                 id=None, tm=0, cmdData=None, args=[]):
         '''Create a new command with given type, name, id, cmdData and args list.'''
         self.type, self.name, self.id, self.time, self.cmdData, self.args = type, name, id, tm, cmdData, args[
             :]
 
     def __repr__(self):
-        return ("<Command type=%r name=%r id=%r data=%r args=%r>" % (self.type, self.name, self.id, self.cmdData, self.args))
+        return ("<Command type=%r name=%r id=%r data=%r args=%r>" %
+                (self.type, self.name, self.id, self.cmdData, self.args))
 
     def setArg(self, arg):
         self.args.append(arg)
@@ -732,7 +747,7 @@ class FLV(object):
         self.tsp = self.tsr = 0
         self.tsr0 = None
 
-    def open(self, path, type='read', mode=0775):
+    def open(self, path, type='read', mode=0o775):
         '''Open the file for reading (type=read) or writing (type=record or append).'''
         if str(path).find('/../') >= 0 or str(path).find('\\..\\') >= 0:
             raise ValueError('Must not contain .. in name')
@@ -745,7 +760,7 @@ class FLV(object):
         if type in ('record', 'append'):
             try:
                 os.makedirs(os.path.dirname(path), mode)
-            except:
+            except BaseException:
                 pass
             # if file does not exist, use record mode
             if type == 'record' or not os.path.exists(path):
@@ -757,7 +772,7 @@ class FLV(object):
                 self.fp = open(path, 'r+b')
                 self.fp.seek(-4, os.SEEK_END)
                 ptagsize, = struct.unpack('>I', self.fp.read(4))
-                self.fp.seek(-4-ptagsize, os.SEEK_END)
+                self.fp.seek(-4 - ptagsize, os.SEEK_END)
                 bytes = self.fp.read(ptagsize)
                 type, len0, len1, ts0, ts1, ts2, sid0, sid1 = struct.unpack(
                     '>BBHBHBBH', bytes[:11])
@@ -775,7 +790,7 @@ class FLV(object):
             if version != 1:
                 raise ValueError('Unsupported FLV file version')
             if offset > 9:
-                self.fp.seek(offset-9, os.SEEK_CUR)
+                self.fp.seek(offset - 9, os.SEEK_CUR)
             self.fp.read(4)  # ignore first previous tag size
         return self
 
@@ -784,11 +799,11 @@ class FLV(object):
         if _debug:
             print 'closing flv file'
         if self.type in ('record', 'append') and self.tsr0 is not None:
-            self.writeDuration((self.tsr - self.tsr0)/1000.0)
+            self.writeDuration((self.tsr - self.tsr0) / 1000.0)
         if self.fp is not None:
             try:
                 self.fp.close()
-            except:
+            except BaseException:
                 pass
             self.fp = None
 
@@ -796,7 +811,7 @@ class FLV(object):
         '''Delete the underlying file for this object.'''
         try:
             os.unlink(path)
-        except:
+        except BaseException:
             pass
 
     def writeDuration(self, duration):
@@ -848,7 +863,7 @@ class FLV(object):
                 if len(bytes) == 0:
                     try:
                         tm = stream.client.relativeTime
-                    except:
+                    except BaseException:
                         tm = 0
                     response = Command(name='onStatus', id=stream.id, tm=tm, args=[amf.Object(
                         level='status', code='NetStream.Play.Stop', description='File ended', details=None)])
@@ -860,9 +875,9 @@ class FLV(object):
                 ts = (ts0 << 16) | (ts1 & 0x0ffff) | (ts2 << 24)
                 body = self.fp.read(length)
                 ptagsize, = struct.unpack('>I', self.fp.read(4))
-                if ptagsize != (length+11):
+                if ptagsize != (length + 11):
                     if _debug:
-                        print 'invalid previous tag-size found:', ptagsize, '!=', (length+11), 'ignored.'
+                        print 'invalid previous tag-size found:', ptagsize, '!=', (length + 11), 'ignored.'
                 if stream is None or stream.client is None:
                     break  # if it is closed
                 #hdr = Header(3 if type == Message.AUDIO else 4, ts if ts < 0xffffff else 0xffffff, length, type, stream.id)
@@ -884,13 +899,13 @@ class FLV(object):
                     yield multitask.sleep(diff / 1000.0)
         except StopIteration:
             pass
-        except:
+        except BaseException:
             if _debug:
                 print 'closing the reader', (sys and sys.exc_info() or None)
             if self.fp is not None:
                 try:
                     self.fp.close()
-                except:
+                except BaseException:
                     pass
                 self.fp = None
 
@@ -903,7 +918,7 @@ class FLV(object):
             magic, version, flags, length = struct.unpack(
                 '!3sBBI', self.fp.read(9))
             if length > 9:
-                self.fp.seek(length-9, os.SEEK_CUR)
+                self.fp.seek(length - 9, os.SEEK_CUR)
             self.fp.seek(4, os.SEEK_CUR)  # ignore first previous tag size
             self.tsp, ts = int(offset), 0
             while self.tsp > 0 and ts < self.tsp:
@@ -916,7 +931,7 @@ class FLV(object):
                 ts = (ts0 << 16) | (ts1 & 0x0ffff) | (ts2 << 24)
                 self.fp.seek(length, os.SEEK_CUR)
                 ptagsize, = struct.unpack('>I', self.fp.read(4))
-                if ptagsize != (length+11):
+                if ptagsize != (length + 11):
                     break
             if _debug:
                 print 'FLV.seek() new ts=', ts, 'tell', self.fp.tell()
@@ -971,7 +986,7 @@ class Client(Protocol):
     def __init__(self, sock, server):
         Protocol.__init__(self, sock)
         self.server, self.agent, self.streams, self._nextCallId, self._nextStreamId, self.objectEncoding = \
-            server,      None,         {},           2,                1,                  0.0
+            server, None, {}, 2, 1, 0.0
         self.queue = multitask.Queue()  # receive queue used by application
         multitask.add(self.parse())
         multitask.add(self.write())
@@ -988,7 +1003,8 @@ class Client(Protocol):
         yield self.queue.put((None, None))
 
     def messageReceived(self, msg):
-        if (msg.type == Message.RPC or msg.type == Message.RPC3) and msg.streamId == 0:
+        if (msg.type == Message.RPC or msg.type ==
+                Message.RPC3) and msg.streamId == 0:
             cmd = Command.fromMessage(msg)
             # if _debug: print 'rtmp.Client.messageReceived cmd=', cmd
             if cmd.name == 'connect':
@@ -1101,7 +1117,7 @@ class Server(object):
             while True:
                 # receive client TCP
                 sock, remote = (yield multitask.accept(self.sock))
-                if sock == None:
+                if sock is None:
                     if _debug:
                         print 'rtmp.Server accept(sock) returned None.'
                     break
@@ -1112,7 +1128,7 @@ class Server(object):
                 client = Client(sock, self)
         except GeneratorExit:
             pass  # terminate
-        except:
+        except BaseException:
             if _debug:
                 print 'rtmp.Server exception ', (sys and sys.exc_info() or None)
 
@@ -1120,7 +1136,7 @@ class Server(object):
             try:
                 self.sock.close()
                 self.sock = None
-            except:
+            except BaseException:
                 pass
         if (self.queue):
             yield self.queue.put((None, None))
@@ -1185,7 +1201,8 @@ class App(object):
         if _debug:
             print self.name, 'onResult', result
 
-    # this is invoked every time some media packet is received from published stream.
+    # this is invoked every time some media packet is received from published
+    # stream.
     def onPublishData(self, client, stream, message):
         return True  # should return True so that the data is actually published in that stream
 
@@ -1201,7 +1218,8 @@ class App(object):
         elif mode in ('record', 'append'):
             path = getfilename(path, name, root)
             return FLV().open(path, mode)
-#        elif stream.mode == 'live': FLV().delete(path) # TODO: this is commented out to avoid accidental delete
+# elif stream.mode == 'live': FLV().delete(path) # TODO: this is commented
+# out to avoid accidental delete
         return None
 
 
@@ -1233,7 +1251,8 @@ class Wirecast(App):
             multitask.add(stream.send(publisher.metaData.dup()))
 
     def onPublishData(self, client, stream, message):
-        # store the first meta data on this published stream for late joining players
+        # store the first meta data on this published stream for late joining
+        # players
         if message.type == Message.DATA and not stream.metaData:
             stream.metaData = message.dup()
         # H264Avc intra + seq, store it
@@ -1294,7 +1313,7 @@ class FlashServer(object):
             try:
                 self.sock.close()
                 self.sock = None
-            except:
+            except BaseException:
                 pass
         self.server = None
 
@@ -1343,7 +1362,7 @@ class FlashServer(object):
 
                         try:
                             result = inst.onConnect(client, *args)
-                        except:
+                        except BaseException:
                             if _debug:
                                 print sys.exc_info()
                             yield client.rejectConnection(reason='Exception on onConnect')
@@ -1363,7 +1382,7 @@ class FlashServer(object):
             pass  # terminate
         except StopIteration:
             raise
-        except:
+        except BaseException:
             if _debug:
                 print 'serverlistener exception', traceback.print_exc()
 
@@ -1385,7 +1404,7 @@ class FlashServer(object):
                     multitask.add(self.streamlistener(arg))
         except StopIteration:
             raise
-        except:
+        except BaseException:
             if _debug:
                 print 'clientlistener exception', (sys and sys.exc_info() or None)
 
@@ -1397,11 +1416,13 @@ class FlashServer(object):
             if client.path in self.clients:
                 inst = self.clients[client.path][0]
                 self.clients[client.path].remove(client)
-            for stream in client.streams.values():  # for all streams of this client
+            for stream in client.streams.values(
+            ):  # for all streams of this client
                 self.closehandler(stream)
             client.streams.clear()  # and clear the collection of streams
             # no more clients left, delete the instance.
-            if client.path in self.clients and len(self.clients[client.path]) == 1:
+            if client.path in self.clients and len(
+                    self.clients[client.path]) == 1:
                 if _debug:
                     print 'removing the application instance'
                 inst = self.clients[client.path][0]
@@ -1409,7 +1430,7 @@ class FlashServer(object):
                 del self.clients[client.path]
             if inst is not None:
                 inst.onDisconnect(client)
-        except:
+        except BaseException:
             if _debug:
                 print 'clientlistener exception', (sys and sys.exc_info() or None)
 
@@ -1442,7 +1463,7 @@ class FlashServer(object):
                 res, code, result = Command(), '_result', None
                 try:
                     result = inst.onCommand(client, cmd.name, *cmd.args)
-                except:
+                except BaseException:
                     if _debug:
                         print 'Client.call exception', (sys and sys.exc_info() or None)
                     code = '_error'
@@ -1467,7 +1488,7 @@ class FlashServer(object):
                     break
                 # if _debug: msg
                 multitask.add(self.streamhandler(stream, msg))
-        except:
+        except BaseException:
             if _debug:
                 print 'streamlistener exception', (sys and sys.exc_info() or None)
 
@@ -1492,7 +1513,7 @@ class FlashServer(object):
             pass
         except StopIteration:
             raise
-        except:
+        except BaseException:
             if _debug:
                 print 'exception in streamhandler', (sys and sys.exc_info())
 
@@ -1508,7 +1529,7 @@ class FlashServer(object):
                 stream.name = stream.name.partition('?')[0]
             inst = self.clients[stream.client.path][0]
             if (stream.name in inst.publishers):
-                raise ValueError, 'Stream name already in use'
+                raise ValueError('Stream name already in use')
             # store the client for publisher
             inst.publishers[stream.name] = stream
             inst.onPublish(stream.client, stream)
@@ -1518,7 +1539,7 @@ class FlashServer(object):
             response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[
                                amf.Object(level='status', code='NetStream.Publish.Start', description='', details=None)])
             yield stream.send(response)
-        except ValueError, E:  # some error occurred. inform the app.
+        except ValueError as E:  # some error occurred. inform the app.
             if _debug:
                 print 'error in publishing stream', str(E)
             response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(
@@ -1548,7 +1569,7 @@ class FlashServer(object):
                         stream.playfile.seek(start)
                     task = stream.playfile.reader(stream)
                 elif start >= 0:
-                    raise ValueError, 'Stream name not found'
+                    raise ValueError('Stream name not found')
             if _debug:
                 print 'playing stream=', name, 'start=', start
             inst.onPlay(stream.client, stream)
@@ -1582,7 +1603,7 @@ class FlashServer(object):
 
             if task is not None:
                 multitask.add(task)
-        except ValueError, E:  # some error occurred. inform the app.
+        except ValueError as E:  # some error occurred. inform the app.
             if _debug:
                 print 'error in playing stream', str(E)
             response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(
@@ -1594,12 +1615,12 @@ class FlashServer(object):
         try:
             offset = cmd.args[0]
             if stream.playfile is None or stream.playfile.type != 'read':
-                raise ValueError, 'Stream is not seekable'
+                raise ValueError('Stream is not seekable')
             stream.playfile.seek(offset)
             response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(
                 level='status', code='NetStream.Seek.Notify', description=stream.name, details=None)])
             yield stream.send(response)
-        except ValueError, E:  # some error occurred. inform the app.
+        except ValueError as E:  # some error occurred. inform the app.
             if _debug:
                 print 'error in seeking stream', str(E)
             response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[
@@ -1626,11 +1647,11 @@ class FlashServer(object):
 if __name__ == '__main__':
     from optparse import OptionParser
     parser = OptionParser(version='SVN $Revision$, $Date$'.replace('$', ''))
-    parser.add_option('-i', '--host',    dest='host',    default='0.0.0.0',
+    parser.add_option('-i', '--host', dest='host', default='0.0.0.0',
                       help="listening IP address. Default '0.0.0.0'")
-    parser.add_option('-p', '--port',    dest='port',    default=1935,
+    parser.add_option('-p', '--port', dest='port', default=1935,
                       type="int", help='listening port number. Default 1935')
-    parser.add_option('-r', '--root',    dest='root',    default='./',
+    parser.add_option('-r', '--root', dest='root', default='./',
                       help="document path prefix. Directory must end with /. Default './'")
     parser.add_option('-d', '--verbose', dest='verbose', default=False,
                       action='store_true', help='enable debug trace')

--- a/tests/rtmplite/rtmp.py
+++ b/tests/rtmplite/rtmp.py
@@ -61,51 +61,75 @@ throw an exception and display the error message.
 
 '''
 
-import os, sys, time, struct, socket, traceback, multitask, amf, hashlib, hmac, random
+import os
+import sys
+import time
+import struct
+import socket
+import traceback
+import multitask
+import amf
+import hashlib
+import hmac
+import random
 
 _debug = False
+
 
 class ConnectionClosed:
     'raised when the client closed the connection'
 
+
 def truncate(data, max=100):
-    return data and len(data)>max and data[:max] + '...(%d)'%(len(data),) or data
-    
+    return data and len(data) > max and data[:max] + '...(%d)' % (len(data),) or data
+
+
 class SockStream(object):
     '''A class that represents a socket as a stream'''
+
     def __init__(self, sock):
         self.sock, self.buffer = sock, ''
         self.bytesWritten = self.bytesRead = 0
-    
+
     def close(self):
         self.sock.close()
-        
+
     def read(self, count):
         try:
             while True:
-                if len(self.buffer) >= count: # do have enough data in buffer
+                if len(self.buffer) >= count:  # do have enough data in buffer
                     data, self.buffer = self.buffer[:count], self.buffer[count:]
                     raise StopIteration(data)
-                if _debug: print 'socket.read[%d] calling recv()'%(count,)
-                data = (yield multitask.recv(self.sock, 4096)) # read more from socket
-                if not data: raise ConnectionClosed
-                if _debug: print 'socket.read[%d] %r'%(len(data), truncate(data))
+                if _debug:
+                    print 'socket.read[%d] calling recv()' % (count,)
+                # read more from socket
+                data = (yield multitask.recv(self.sock, 4096))
+                if not data:
+                    raise ConnectionClosed
+                if _debug:
+                    print 'socket.read[%d] %r' % (len(data), truncate(data))
                 self.bytesRead += len(data)
                 self.buffer += data
-        except StopIteration: raise
-        except: raise ConnectionClosed # anything else is treated as connection closed.
-        
+        except StopIteration:
+            raise
+        except:
+            # anything else is treated as connection closed.
+            raise ConnectionClosed
+
     def unread(self, data):
         self.buffer = data + self.buffer
-            
+
     def write(self, data):
-        while len(data) > 0: # write in 4K chunks each time
+        while len(data) > 0:  # write in 4K chunks each time
             chunk, data = data[:4096], data[4096:]
             self.bytesWritten += len(chunk)
-            if _debug: print 'socket.write[%d] %r'%(len(chunk), truncate(chunk))
-            try: yield multitask.send(self.sock, chunk)
-            except: raise ConnectionClosed
-                                
+            if _debug:
+                print 'socket.write[%d] %r' % (len(chunk), truncate(chunk))
+            try:
+                yield multitask.send(self.sock, chunk)
+            except:
+                raise ConnectionClosed
+
 
 '''
 NOTE: Here is a part of the documentation to understand how the Chunks' headers work.
@@ -179,39 +203,47 @@ present. Type 3 chunks MUST NOT have this field. This field if transmitted is lo
 and before the chunk data. 
 
 '''
+
+
 class Header(object):
     # Chunk type 0 = FULL
     # Chunk type 1 = MESSAGE
     # Chunk type 2 = TIME
     # Chunk type 3 = SEPARATOR
     FULL, MESSAGE, TIME, SEPARATOR, MASK = 0x00, 0x40, 0x80, 0xC0, 0xC0
-    
+
     def __init__(self, channel=0, time=0, size=None, type=None, streamId=0):
-        
+
         self.channel = channel   # in fact, this will be the fmt + cs id
         self.time = time         # timestamp[delta]
         self.size = size         # message length
         self.type = type         # message type id
-        self.streamId = streamId # message stream id
-        
-        if (channel < 64): self.hdrdata = struct.pack('>B', channel)
-        elif (channel < 320): self.hdrdata = '\x00' + struct.pack('>B', channel-64)
-        else: self.hdrdata = '\x01' + struct.pack('>H', channel-64)
-    
+        self.streamId = streamId  # message stream id
+
+        if (channel < 64):
+            self.hdrdata = struct.pack('>B', channel)
+        elif (channel < 320):
+            self.hdrdata = '\x00' + struct.pack('>B', channel-64)
+        else:
+            self.hdrdata = '\x01' + struct.pack('>H', channel-64)
+
     def toBytes(self, control):
         data = chr(ord(self.hdrdata[0]) | control)
-        if len(self.hdrdata) >= 2: data += self.hdrdata[1:] 
-        
+        if len(self.hdrdata) >= 2:
+            data += self.hdrdata[1:]
+
         # if the chunk type is not 3
         if control != Header.SEPARATOR:
-            data += struct.pack('>I', self.time if self.time < 0xFFFFFF else 0xFFFFFF)[1:] # add time in 3 bytes
+            data += struct.pack('>I', self.time if self.time <
+                                0xFFFFFF else 0xFFFFFF)[1:]  # add time in 3 bytes
             # if the chunk type is not 2
             if control != Header.TIME:
-                data += struct.pack('>I', self.size)[1:] # add size in 3 bytes
-                data += struct.pack('>B', self.type) # add type in 1 byte
+                data += struct.pack('>I', self.size)[1:]  # add size in 3 bytes
+                data += struct.pack('>B', self.type)  # add type in 1 byte
                 # if the chunk type is not 1
                 if control != Header.MESSAGE:
-                    data += struct.pack('<I', self.streamId) # add streamId in little-endian 4 bytes
+                    # add streamId in little-endian 4 bytes
+                    data += struct.pack('<I', self.streamId)
             # add the extended time part to the header if timestamp[delta] >= 16777215
             if self.time >= 0xFFFFFF:
                 data += struct.pack('>I', self.time)
@@ -219,8 +251,8 @@ class Header(object):
 
     def __repr__(self):
         return ("<Header channel=%r time=%r size=%r type=%s (%r) streamId=%r>"
-            % (self.channel, self.time, self.size, Message.type_name.get(self.type, 'unknown'), self.type, self.streamId))
-    
+                % (self.channel, self.time, self.size, Message.type_name.get(self.type, 'unknown'), self.type, self.streamId))
+
     def dup(self):
         return Header(channel=self.channel, time=self.time, size=self.size, type=self.type, streamId=self.streamId)
 
@@ -228,30 +260,32 @@ class Header(object):
 class Message(object):
     # message types: RPC3, DATA3,and SHAREDOBJECT3 are used with AMF3
     CHUNK_SIZE,   ABORT,   ACK,   USER_CONTROL, WIN_ACK_SIZE, SET_PEER_BW, AUDIO, VIDEO, DATA3, SHAREDOBJ3, RPC3, DATA, SHAREDOBJ, RPC, AGGREGATE = \
-    0x01,         0x02,    0x03,  0x04,         0x05,         0x06,        0x08,  0x09,  0x0F,  0x10,       0x11, 0x12, 0x13,      0x14, 0x16
+        0x01,         0x02,    0x03,  0x04,         0x05,         0x06,        0x08,  0x09,  0x0F,  0x10,       0x11, 0x12, 0x13,      0x14, 0x16
     type_name = dict(enumerate('unknown chunk-size abort ack user-control win-ack-size set-peer-bw unknown audio video unknown unknown unknown unknown unknown data3 sharedobj3 rpc3 data sharedobj rpc unknown aggregate'.split()))
-    
+
     def __init__(self, hdr=None, data=''):
         self.header, self.data = hdr or Header(), data
-    
+
     # define properties type, streamId and time to access self.header.(property)
     for p in ['type', 'streamId', 'time']:
-        exec 'def _g%s(self): return self.header.%s'%(p, p)
-        exec 'def _s%s(self, %s): self.header.%s = %s'%(p, p, p, p)
-        exec '%s = property(fget=_g%s, fset=_s%s)'%(p, p, p)
+        exec 'def _g%s(self): return self.header.%s' % (p, p)
+        exec 'def _s%s(self, %s): self.header.%s = %s' % (p, p, p, p)
+        exec '%s = property(fget=_g%s, fset=_s%s)' % (p, p, p)
+
     @property
     def size(self): return len(self.data)
-            
+
     def __repr__(self):
-        return ("<Message header=%r data=%r>"% (self.header, truncate(self.data)))
-    
+        return ("<Message header=%r data=%r>" % (self.header, truncate(self.data)))
+
     def dup(self):
         return Message(self.header.dup(), self.data[:])
-                
+
+
 class Protocol(object):
-    PING_SIZE, DEFAULT_CHUNK_SIZE, HIGH_WRITE_CHUNK_SIZE, PROTOCOL_CHANNEL_ID = 1536, 128, 4096, 2 # constants
+    PING_SIZE, DEFAULT_CHUNK_SIZE, HIGH_WRITE_CHUNK_SIZE, PROTOCOL_CHANNEL_ID = 1536, 128, 4096, 2  # constants
     READ_WIN_SIZE, WRITE_WIN_SIZE = 1000000L, 1073741824L
-    
+
     def __init__(self, sock):
         self.stream = SockStream(sock)
         self.lastReadHeaders, self.incompletePackets, self.lastWriteHeaders = dict(), dict(), dict()
@@ -260,59 +294,66 @@ class Protocol(object):
         self.nextChannelId = Protocol.PROTOCOL_CHANNEL_ID + 1
         self._time0 = time.time()
         self.writeQueue = multitask.Queue()
-            
+
     @property
     def relativeTime(self):
         return int(1000*(time.time() - self._time0))
-    
-    def messageReceived(self, msg): # override in subclass
+
+    def messageReceived(self, msg):  # override in subclass
         yield
-            
+
     def protocolMessage(self, msg):
-        if msg.type == Message.ACK: # respond to ACK requests
+        if msg.type == Message.ACK:  # respond to ACK requests
             self.writeWinSize0 = struct.unpack('>L', msg.data)[0]
 #            response = Message()
 #            response.type, response.data = msg.type, msg.data
 #            yield self.writeMessage(response)
         elif msg.type == Message.CHUNK_SIZE:
             self.readChunkSize = struct.unpack('>L', msg.data)[0]
-            if _debug: print "set read chunk size to %d" % self.readChunkSize
+            if _debug:
+                print "set read chunk size to %d" % self.readChunkSize
         elif msg.type == Message.WIN_ACK_SIZE:
-            self.readWinSize, self.readWinSize0 = struct.unpack('>L', msg.data)[0], self.stream.bytesRead
+            self.readWinSize, self.readWinSize0 = struct.unpack(
+                '>L', msg.data)[0], self.stream.bytesRead
         elif msg.type == Message.USER_CONTROL:
             type, data = struct.unpack('>H', msg.data[:2])[0], msg.data[2:]
-            if type == 3: # client expects a response when it sends set buffer length
+            if type == 3:  # client expects a response when it sends set buffer length
                 streamId, bufferTime = struct.unpack('>II', data)
                 response = Message()
-                response.time, response.type, response.data = self.relativeTime, Message.USER_CONTROL, struct.pack('>HI', 0, streamId)
+                response.time, response.type, response.data = self.relativeTime, Message.USER_CONTROL, struct.pack(
+                    '>HI', 0, streamId)
                 yield self.writeMessage(response)
         yield
-        
+
     def connectionClosed(self):
         yield
-                            
+
     def parse(self):
         try:
-            yield self.parseCrossDomainPolicyRequest() # check for cross domain policy
+            yield self.parseCrossDomainPolicyRequest()  # check for cross domain policy
             yield self.parseHandshake()  # parse rtmp handshake
             yield self.parseMessages()   # parse messages
         except ConnectionClosed:
             yield self.connectionClosed()
-            if _debug: print 'parse connection closed'
+            if _debug:
+                print 'parse connection closed'
         except:
-            if _debug: print 'exception, closing connection'
-            if _debug: traceback.print_exc()
+            if _debug:
+                print 'exception, closing connection'
+            if _debug:
+                traceback.print_exc()
             yield self.connectionClosed()
-                    
+
     def writeMessage(self, message):
         yield self.writeQueue.put(message)
-            
+
     def parseCrossDomainPolicyRequest(self):
         # read the request
         REQUEST = '<policy-file-request/>\x00'
         data = (yield self.stream.read(len(REQUEST)))
         if data == REQUEST:
-            if _debug: print data
+            if _debug:
+                print data
             data = '''<!DOCTYPE cross-domain-policy SYSTEM "http://www.macromedia.com/xml/dtds/cross-domain-policy.dtd">
                     <cross-domain-policy>
                       <allow-access-from domain="*" to-ports="1935" secure='false'/>
@@ -321,17 +362,17 @@ class Protocol(object):
             raise ConnectionClosed
         else:
             yield self.stream.unread(data)
-            
+
     SERVER_KEY = '\x47\x65\x6e\x75\x69\x6e\x65\x20\x41\x64\x6f\x62\x65\x20\x46\x6c\x61\x73\x68\x20\x4d\x65\x64\x69\x61\x20\x53\x65\x72\x76\x65\x72\x20\x30\x30\x31\xf0\xee\xc2\x4a\x80\x68\xbe\xe8\x2e\x00\xd0\xd1\x02\x9e\x7e\x57\x6e\xec\x5d\x2d\x29\x80\x6f\xab\x93\xb8\xe6\x36\xcf\xeb\x31\xae'
     FLASHPLAYER_KEY = '\x47\x65\x6E\x75\x69\x6E\x65\x20\x41\x64\x6F\x62\x65\x20\x46\x6C\x61\x73\x68\x20\x50\x6C\x61\x79\x65\x72\x20\x30\x30\x31\xF0\xEE\xC2\x4A\x80\x68\xBE\xE8\x2E\x00\xD0\xD1\x02\x9E\x7E\x57\x6E\xEC\x5D\x2D\x29\x80\x6F\xAB\x93\xB8\xE6\x36\xCF\xEB\x31\xAE'
-    
+
     def parseHandshake(self):
         '''Parses the rtmp handshake'''
-        data = (yield self.stream.read(Protocol.PING_SIZE + 1)) # bound version and first ping
+        data = (yield self.stream.read(Protocol.PING_SIZE + 1))  # bound version and first ping
         data = Protocol.handshakeResponse(data)
         yield self.stream.write(data)
         data = (yield self.stream.read(Protocol.PING_SIZE))
-    
+
     @staticmethod
     def handshakeResponse(data):
         # send both data parts before reading next ping-size, to work with ffmpeg
@@ -339,55 +380,71 @@ class Protocol(object):
             data = '\x03' + '\x00'*Protocol.PING_SIZE
             return data + data[1:]
         else:
-            type, data = ord(data[0]), data[1:] # first byte is ignored
+            type, data = ord(data[0]), data[1:]  # first byte is ignored
             scheme = None
             for s in range(0, 2):
-                digest_offset = (sum([ord(data[i]) for i in range(772, 776)]) % 728 + 776) if s == 1 else (sum([ord(data[i]) for i in range(8, 12)]) % 728 + 12)
-                temp = data[0:digest_offset] + data[digest_offset+32:Protocol.PING_SIZE]
-                hash = Protocol._calculateHash(temp, Protocol.FLASHPLAYER_KEY[:30])
+                digest_offset = (sum([ord(data[i]) for i in range(
+                    772, 776)]) % 728 + 776) if s == 1 else (sum([ord(data[i]) for i in range(8, 12)]) % 728 + 12)
+                temp = data[0:digest_offset] + \
+                    data[digest_offset+32:Protocol.PING_SIZE]
+                hash = Protocol._calculateHash(
+                    temp, Protocol.FLASHPLAYER_KEY[:30])
                 if hash == data[digest_offset:digest_offset+32]:
                     scheme = s
                     break
             if scheme is None:
-                if _debug: print 'invalid RTMP connection data, assuming scheme 0'
+                if _debug:
+                    print 'invalid RTMP connection data, assuming scheme 0'
                 scheme = 0
-            client_dh_offset = (sum([ord(data[i]) for i in range(768, 772)]) % 632 + 8) if scheme == 1 else (sum([ord(data[i]) for i in range(1532, 1536)]) % 632 + 772)
+            client_dh_offset = (sum([ord(data[i]) for i in range(768, 772)]) % 632 + 8) if scheme == 1 else (
+                sum([ord(data[i]) for i in range(1532, 1536)]) % 632 + 772)
             outgoingKp = data[client_dh_offset:client_dh_offset+128]
-            handshake = struct.pack('>IBBBB', 0, 1, 2, 3, 4) + ''.join([chr(random.randint(0, 255)) for i in xrange(Protocol.PING_SIZE-8)])
-            server_dh_offset = (sum([ord(handshake[i]) for i in range(768, 772)]) % 632 + 8) if scheme == 1 else (sum([ord(handshake[i]) for i in range(1532, 1536)]) % 632 + 772)
-            keys = Protocol._generateKeyPair() # (public, private)
-            handshake = handshake[:server_dh_offset] + keys[0][0:128] + handshake[server_dh_offset+128:]
-            if type > 0x03: raise Exception('encryption is not supported')
-            server_digest_offset = (sum([ord(handshake[i]) for i in range(772, 776)]) % 728 + 776) if scheme == 1 else (sum([ord(handshake[i]) for i in range(8, 12)]) % 728 + 12)
-            temp = handshake[0:server_digest_offset] + handshake[server_digest_offset+32:Protocol.PING_SIZE]
+            handshake = struct.pack('>IBBBB', 0, 1, 2, 3, 4) + ''.join(
+                [chr(random.randint(0, 255)) for i in xrange(Protocol.PING_SIZE-8)])
+            server_dh_offset = (sum([ord(handshake[i]) for i in range(768, 772)]) % 632 + 8) if scheme == 1 else (
+                sum([ord(handshake[i]) for i in range(1532, 1536)]) % 632 + 772)
+            keys = Protocol._generateKeyPair()  # (public, private)
+            handshake = handshake[:server_dh_offset] + \
+                keys[0][0:128] + handshake[server_dh_offset+128:]
+            if type > 0x03:
+                raise Exception('encryption is not supported')
+            server_digest_offset = (sum([ord(handshake[i]) for i in range(
+                772, 776)]) % 728 + 776) if scheme == 1 else (sum([ord(handshake[i]) for i in range(8, 12)]) % 728 + 12)
+            temp = handshake[0:server_digest_offset] + \
+                handshake[server_digest_offset+32:Protocol.PING_SIZE]
             hash = Protocol._calculateHash(temp, Protocol.SERVER_KEY[:36])
-            handshake = handshake[:server_digest_offset] + hash + handshake[server_digest_offset+32:]
+            handshake = handshake[:server_digest_offset] + \
+                hash + handshake[server_digest_offset+32:]
             buffer = data[:Protocol.PING_SIZE-32]
-            key_challenge_offset = (sum([ord(buffer[i]) for i in range(772, 776)]) % 728 + 776) if scheme == 1 else (sum([ord(buffer[i]) for i in range(8, 12)]) % 728 + 12)
+            key_challenge_offset = (sum([ord(buffer[i]) for i in range(
+                772, 776)]) % 728 + 776) if scheme == 1 else (sum([ord(buffer[i]) for i in range(8, 12)]) % 728 + 12)
             challenge_key = data[key_challenge_offset:key_challenge_offset+32]
-            hash = Protocol._calculateHash(challenge_key, Protocol.SERVER_KEY[:68])
-            rand_bytes = ''.join([chr(random.randint(0, 255)) for i in xrange(Protocol.PING_SIZE-32)])
+            hash = Protocol._calculateHash(
+                challenge_key, Protocol.SERVER_KEY[:68])
+            rand_bytes = ''.join([chr(random.randint(0, 255))
+                                  for i in xrange(Protocol.PING_SIZE-32)])
             last_hash = Protocol._calculateHash(rand_bytes, hash[:32])
             output = chr(type) + handshake + rand_bytes + last_hash
             return output
-        
+
     @staticmethod
-    def _calculateHash(msg, key): # Hmac-sha256
+    def _calculateHash(msg, key):  # Hmac-sha256
         return hmac.new(key, msg, hashlib.sha256).digest()
-        
+
     @staticmethod
-    def _generateKeyPair(): # dummy key pair since we don't support encryption
+    def _generateKeyPair():  # dummy key pair since we don't support encryption
         return (''.join([chr(random.randint(0, 255)) for i in xrange(128)]), '')
-        
+
     def parseMessages(self):
         '''Parses complete messages until connection closed. Raises ConnectionLost exception.'''
         CHANNEL_MASK = 0x3F
         while True:
-            hdrsize = ord((yield self.stream.read(1))[0])  # read header size byte
+            # read header size byte
+            hdrsize = ord((yield self.stream.read(1))[0])
             channel = hdrsize & CHANNEL_MASK
-            if channel == 0: # we need one more byte
+            if channel == 0:  # we need one more byte
                 channel = 64 + ord((yield self.stream.read(1))[0])
-            elif channel == 1: # we need two more bytes
+            elif channel == 1:  # we need two more bytes
                 data = (yield self.stream.read(2))
                 channel = 64 + ord(data[0]) + 256 * ord(data[1])
 
@@ -397,41 +454,44 @@ class Protocol(object):
                 self.lastReadHeaders[channel] = header
             else:
                 header = self.lastReadHeaders[channel]
-            
-            if hdrtype < Header.SEPARATOR: # time or delta has changed
+
+            if hdrtype < Header.SEPARATOR:  # time or delta has changed
                 data = (yield self.stream.read(3))
                 header.time = struct.unpack('!I', '\x00' + data)[0]
-                
-            if hdrtype < Header.TIME: # size and type also changed
+
+            if hdrtype < Header.TIME:  # size and type also changed
                 data = (yield self.stream.read(3))
                 header.size = struct.unpack('!I', '\x00' + data)[0]
                 header.type = ord((yield self.stream.read(1))[0])
 
-            if hdrtype < Header.MESSAGE: # streamId also changed
+            if hdrtype < Header.MESSAGE:  # streamId also changed
                 data = (yield self.stream.read(4))
                 header.streamId = struct.unpack('<I', data)[0]
 
-            if header.time == 0xFFFFFF: # if we have extended timestamp, read it
+            if header.time == 0xFFFFFF:  # if we have extended timestamp, read it
                 data = (yield self.stream.read(4))
                 header.extendedTime = struct.unpack('!I', data)[0]
-                if _debug: print 'extended time stamp', '%x'%(header.extendedTime,)
+                if _debug:
+                    print 'extended time stamp', '%x' % (header.extendedTime,)
             else:
                 header.extendedTime = None
-                
+
             if hdrtype == Header.FULL:
                 header.currentTime = header.extendedTime or header.time
                 header.hdrtype = hdrtype
             elif hdrtype in (Header.MESSAGE, Header.TIME):
                 header.hdrtype = hdrtype
 
-            #print header.type, '0x%02x'%(hdrtype,), header.time, header.currentTime
-            
+            # print header.type, '0x%02x'%(hdrtype,), header.time, header.currentTime
+
             # if _debug: print 'R', header, header.currentTime, header.extendedTime, '0x%x'%(hdrsize,)
-             
-            data = self.incompletePackets.get(channel, "") # are we continuing an incomplete packet?
-            
-            count = min(header.size - (len(data)), self.readChunkSize) # how much more
-            
+
+            # are we continuing an incomplete packet?
+            data = self.incompletePackets.get(channel, "")
+
+            count = min(header.size - (len(data)),
+                        self.readChunkSize)  # how much more
+
             data += (yield self.stream.read(count))
 
             # check if we need to send Ack
@@ -439,33 +499,38 @@ class Protocol(object):
                 if self.stream.bytesRead > (self.readWinSize0 + self.readWinSize):
                     self.readWinSize0 = self.stream.bytesRead
                     ack = Message()
-                    ack.time, ack.type, ack.data = self.relativeTime, Message.ACK, struct.pack('>L', self.readWinSize0)
+                    ack.time, ack.type, ack.data = self.relativeTime, Message.ACK, struct.pack(
+                        '>L', self.readWinSize0)
                     yield self.writeMessage(ack)
-                    
-            if len(data) < header.size: # we don't have all data
+
+            if len(data) < header.size:  # we don't have all data
                 self.incompletePackets[channel] = data
-            else: # we have all data
+            else:  # we have all data
                 if hdrtype in (Header.MESSAGE, Header.TIME):
-                    header.currentTime = header.currentTime + (header.extendedTime or header.time)
+                    header.currentTime = header.currentTime + \
+                        (header.extendedTime or header.time)
                 elif hdrtype == Header.SEPARATOR:
                     if header.hdrtype in (Header.MESSAGE, Header.TIME):
-                        header.currentTime = header.currentTime + (header.extendedTime or header.time)
+                        header.currentTime = header.currentTime + \
+                            (header.extendedTime or header.time)
                 if len(data) == header.size:
                     if channel in self.incompletePackets:
                         del self.incompletePackets[channel]
                         if _debug:
-                            print 'aggregated %r bytes message: readChunkSize(%r) x %r'%(len(data), self.readChunkSize, len(data) / self.readChunkSize)
+                            print 'aggregated %r bytes message: readChunkSize(%r) x %r' % (len(data), self.readChunkSize, len(data) / self.readChunkSize)
                 else:
                     data, self.incompletePackets[channel] = data[:header.size], data[header.size:]
-                
-                hdr = Header(channel=header.channel, time=header.currentTime, size=header.size, type=header.type, streamId=header.streamId)
+
+                hdr = Header(channel=header.channel, time=header.currentTime,
+                             size=header.size, type=header.type, streamId=header.streamId)
                 msg = Message(hdr, data)
 
                 if hdr.type == Message.AGGREGATE:
                     ''' see http://code.google.com/p/red5/source/browse/java/server/trunk/src/org/red5/server/net/rtmp/event/Aggregate.java / getParts()
                     '''
-                    if _debug: print 'Protocol.parseMessages aggregated msg=', msg 
-                    aggdata = data;
+                    if _debug:
+                        print 'Protocol.parseMessages aggregated msg=', msg
+                    aggdata = data
                     while len(aggdata) > 0:
                         '''
                         type=1 byte
@@ -478,56 +543,67 @@ class Protocol(object):
                         subtype = ord(aggdata[0])
                         subsize = struct.unpack('!I', '\x00' + aggdata[1:4])[0]
                         subtime = struct.unpack('!I', aggdata[4:8])[0]
-                        substreamid = struct.unpack('<I', aggdata[8:12])[0]     
-                        subheader = Header(channel, time=subtime, size=subsize, type=subtype, streamId=substreamid) # TODO: set correct channel
-                        aggdata = aggdata[11:] # skip header       
-                        submsgdata = aggdata[:subsize] # get message data 
-                        submsg = Message(subheader, submsgdata) 
-                        
+                        substreamid = struct.unpack('<I', aggdata[8:12])[0]
+                        # TODO: set correct channel
+                        subheader = Header(
+                            channel, time=subtime, size=subsize, type=subtype, streamId=substreamid)
+                        aggdata = aggdata[11:]  # skip header
+                        submsgdata = aggdata[:subsize]  # get message data
+                        submsg = Message(subheader, submsgdata)
+
                         yield self.parseMessage(submsg)
-                                        
-                        aggdata = aggdata[subsize:] # skip message data
-                    
+
+                        aggdata = aggdata[subsize:]  # skip message data
+
                         backpointer = struct.unpack('!I', aggdata[0:4])[0]
                         if backpointer != subsize:
-                            print 'Warning aggregate submsg backpointer=%r != %r' % (backpointer, subsize)                          
-                        aggdata = aggdata[4:] # skip back pointer, go to next message
+                            print 'Warning aggregate submsg backpointer=%r != %r' % (backpointer, subsize)
+                        # skip back pointer, go to next message
+                        aggdata = aggdata[4:]
                 else:
                     yield self.parseMessage(msg)
-                
 
     def parseMessage(self, msg):
-        try:            
-            if _debug: print 'Protocol.parseMessage msg=', msg            
+        try:
+            if _debug:
+                print 'Protocol.parseMessage msg=', msg
             if msg.header.channel == Protocol.PROTOCOL_CHANNEL_ID:
                 yield self.protocolMessage(msg)
-            else: 
+            else:
                 yield self.messageReceived(msg)
         except:
-            if _debug: print 'Protocol.parseMessage exception', (traceback and traceback.print_exc() or None)
+            if _debug:
+                print 'Protocol.parseMessage exception', (traceback and traceback.print_exc() or None)
 
     def write(self):
         '''Writes messages to stream'''
         while True:
-#            while self.writeQueue.empty(): (yield multitask.sleep(0.01))
-#            message = self.writeQueue.get() # TODO this should be used using multitask.Queue and remove previous wait.
-            message = yield self.writeQueue.get() # TODO this should be used using multitask.Queue and remove previous wait.
-            if _debug: print 'Protocol.write msg=', message
-            if message is None: 
-                try: self.stream.close()  # just in case TCP socket is not closed, close it.
-                except: pass
+            #            while self.writeQueue.empty(): (yield multitask.sleep(0.01))
+            #            message = self.writeQueue.get() # TODO this should be used using multitask.Queue and remove previous wait.
+            # TODO this should be used using multitask.Queue and remove previous wait.
+            message = yield self.writeQueue.get()
+            if _debug:
+                print 'Protocol.write msg=', message
+            if message is None:
+                try:
+                    # just in case TCP socket is not closed, close it.
+                    self.stream.close()
+                except:
+                    pass
                 break
-            
+
             # get the header stored for the stream
             if self.lastWriteHeaders.has_key(message.streamId):
                 header = self.lastWriteHeaders[message.streamId]
             else:
-                if self.nextChannelId <= Protocol.PROTOCOL_CHANNEL_ID: self.nextChannelId = Protocol.PROTOCOL_CHANNEL_ID+1
-                header, self.nextChannelId = Header(self.nextChannelId), self.nextChannelId + 1
+                if self.nextChannelId <= Protocol.PROTOCOL_CHANNEL_ID:
+                    self.nextChannelId = Protocol.PROTOCOL_CHANNEL_ID+1
+                header, self.nextChannelId = Header(
+                    self.nextChannelId), self.nextChannelId + 1
                 self.lastWriteHeaders[message.streamId] = header
             if message.type < Message.AUDIO:
                 header = Header(Protocol.PROTOCOL_CHANNEL_ID)
-               
+
             # now figure out the header data bytes
             if header.streamId != message.streamId or header.time == 0 or message.time <= header.time:
                 header.streamId, header.type, header.size, header.time, header.delta = message.streamId, message.type, message.size, message.time, message.time
@@ -538,17 +614,18 @@ class Protocol(object):
             else:
                 header.time, header.delta = message.time, message.time-header.time
                 control = Header.TIME
-            
-            hdr = Header(channel=header.channel, time=header.delta if control in (Header.MESSAGE, Header.TIME) else header.time, size=header.size, type=header.type, streamId=header.streamId)
+
+            hdr = Header(channel=header.channel, time=header.delta if control in (
+                Header.MESSAGE, Header.TIME) else header.time, size=header.size, type=header.type, streamId=header.streamId)
             assert message.size == len(message.data)
 
             data = ''
             while len(message.data) > 0:
-                data += hdr.toBytes(control) # gather header bytes
+                data += hdr.toBytes(control)  # gather header bytes
                 count = min(self.writeChunkSize, len(message.data))
                 data += message.data[:count]
                 message.data = message.data[count:]
-                control = Header.SEPARATOR # incomplete message continuation
+                control = Header.SEPARATOR  # incomplete message continuation
             try:
                 yield self.stream.write(data)
             except ConnectionClosed:
@@ -556,55 +633,60 @@ class Protocol(object):
             except:
                 print traceback.print_exc()
 
+
 class Command(object):
     ''' Class for command / data messages'''
+
     def __init__(self, type=Message.RPC, name=None, id=None, tm=0, cmdData=None, args=[]):
         '''Create a new command with given type, name, id, cmdData and args list.'''
-        self.type, self.name, self.id, self.time, self.cmdData, self.args = type, name, id, tm, cmdData, args[:]
-        
+        self.type, self.name, self.id, self.time, self.cmdData, self.args = type, name, id, tm, cmdData, args[
+            :]
+
     def __repr__(self):
         return ("<Command type=%r name=%r id=%r data=%r args=%r>" % (self.type, self.name, self.id, self.cmdData, self.args))
-    
+
     def setArg(self, arg):
         self.args.append(arg)
-    
+
     def getArg(self, index):
         return self.args[index]
-    
+
     @classmethod
     def fromMessage(cls, message):
         ''' initialize from a parsed RTMP message'''
-        assert (message.type in [Message.RPC, Message.RPC3, Message.DATA, Message.DATA3])
+        assert (message.type in [Message.RPC,
+                                 Message.RPC3, Message.DATA, Message.DATA3])
 
         length = len(message.data)
-        if length == 0: raise ValueError('zero length message data')
-        
+        if length == 0:
+            raise ValueError('zero length message data')
+
         if message.type == Message.RPC3 or message.type == Message.DATA3:
-            assert message.data[0] == '\x00' # must be 0 in AMF3
+            assert message.data[0] == '\x00'  # must be 0 in AMF3
             data = message.data[1:]
         else:
             data = message.data
-        
+
         amfReader = amf.AMF0(data)
 
         inst = cls()
         inst.type = message.type
         inst.time = message.time
-        inst.name = amfReader.read() # first field is command name
+        inst.name = amfReader.read()  # first field is command name
 
         try:
             if message.type == Message.RPC or message.type == Message.RPC3:
-                inst.id = amfReader.read() # second field *may* be message id
-                inst.cmdData = amfReader.read() # third is command data
+                inst.id = amfReader.read()  # second field *may* be message id
+                inst.cmdData = amfReader.read()  # third is command data
             else:
                 inst.id = 0
-            inst.args = [] # others are optional
+            inst.args = []  # others are optional
             while True:
                 inst.args.append(amfReader.read())
         except EOFError:
             pass
         return inst
-    
+
     def toMessage(self):
         msg = Message()
         assert self.type
@@ -619,8 +701,8 @@ class Command(object):
         for arg in self.args:
             amfWriter.write(arg)
         output.seek(0)
-        #hexdump.hexdump(output)
-        #output.seek(0)
+        # hexdump.hexdump(output)
+        # output.seek(0)
         if msg.type == Message.RPC3 or msg.type == Message.DATA3:
             data = '\x00' + output.read()
         else:
@@ -629,32 +711,47 @@ class Command(object):
         output.close()
         return msg
 
+
 def getfilename(path, name, root):
     '''return the file name for the given stream. The name is derived as root/scope/name.flv where scope is
     the the path present in the path variable.'''
     ignore, ignore, scope = path.partition('/')
-    if scope: scope = scope + '/'
+    if scope:
+        scope = scope + '/'
     result = root + scope + name + '.flv'
-    if _debug: print 'filename=', result
+    if _debug:
+        print 'filename=', result
     return result
+
 
 class FLV(object):
     '''An FLV file which converts between RTMP message and FLV tags.'''
+
     def __init__(self):
         self.fname = self.fp = self.type = None
-        self.tsp = self.tsr = 0; self.tsr0 = None
-    
+        self.tsp = self.tsr = 0
+        self.tsr0 = None
+
     def open(self, path, type='read', mode=0775):
         '''Open the file for reading (type=read) or writing (type=record or append).'''
-        if str(path).find('/../') >= 0 or str(path).find('\\..\\') >= 0: raise ValueError('Must not contain .. in name')
-        if _debug: print 'opening file', path
-        self.tsp = self.tsr = 0; self.tsr0 = None; self.tsr1 = 0; self.type = type
+        if str(path).find('/../') >= 0 or str(path).find('\\..\\') >= 0:
+            raise ValueError('Must not contain .. in name')
+        if _debug:
+            print 'opening file', path
+        self.tsp = self.tsr = 0
+        self.tsr0 = None
+        self.tsr1 = 0
+        self.type = type
         if type in ('record', 'append'):
-            try: os.makedirs(os.path.dirname(path), mode)
-            except: pass
-            if type == 'record' or not os.path.exists(path): # if file does not exist, use record mode
+            try:
+                os.makedirs(os.path.dirname(path), mode)
+            except:
+                pass
+            # if file does not exist, use record mode
+            if type == 'record' or not os.path.exists(path):
                 self.fp = open(path, 'w+b')
-                self.fp.write('FLV\x01\x05\x00\x00\x00\x09\x00\x00\x00\x00') # the header and first previousTagSize
+                # the header and first previousTagSize
+                self.fp.write('FLV\x01\x05\x00\x00\x00\x09\x00\x00\x00\x00')
                 self.writeDuration(0.0)
             else:
                 self.fp = open(path, 'r+b')
@@ -662,50 +759,66 @@ class FLV(object):
                 ptagsize, = struct.unpack('>I', self.fp.read(4))
                 self.fp.seek(-4-ptagsize, os.SEEK_END)
                 bytes = self.fp.read(ptagsize)
-                type, len0, len1, ts0, ts1, ts2, sid0, sid1 = struct.unpack('>BBHBHBBH', bytes[:11])
+                type, len0, len1, ts0, ts1, ts2, sid0, sid1 = struct.unpack(
+                    '>BBHBHBBH', bytes[:11])
                 ts = (ts0 << 16) | (ts1 & 0x0ffff) | (ts2 << 24)
-                self.tsr1 = ts + 20; # some offset after the last packet
+                self.tsr1 = ts + 20  # some offset after the last packet
                 self.fp.seek(0, os.SEEK_END)
-        else: 
+        else:
             self.fp = open(path, 'rb')
-            magic, version, flags, offset = struct.unpack('!3sBBI', self.fp.read(9))
-            if _debug: print 'FLV.open() hdr=', magic, version, flags, offset
-            if magic != 'FLV': raise ValueError('This is not a FLV file')
-            if version != 1: raise ValueError('Unsupported FLV file version')
-            if offset > 9: self.fp.seek(offset-9, os.SEEK_CUR)
-            self.fp.read(4) # ignore first previous tag size
-        return self 
-    
+            magic, version, flags, offset = struct.unpack(
+                '!3sBBI', self.fp.read(9))
+            if _debug:
+                print 'FLV.open() hdr=', magic, version, flags, offset
+            if magic != 'FLV':
+                raise ValueError('This is not a FLV file')
+            if version != 1:
+                raise ValueError('Unsupported FLV file version')
+            if offset > 9:
+                self.fp.seek(offset-9, os.SEEK_CUR)
+            self.fp.read(4)  # ignore first previous tag size
+        return self
+
     def close(self):
         '''Close the underlying file for this object.'''
-        if _debug: print 'closing flv file'
+        if _debug:
+            print 'closing flv file'
         if self.type in ('record', 'append') and self.tsr0 is not None:
             self.writeDuration((self.tsr - self.tsr0)/1000.0)
-        if self.fp is not None: 
-            try: self.fp.close()
-            except: pass
+        if self.fp is not None:
+            try:
+                self.fp.close()
+            except:
+                pass
             self.fp = None
-    
+
     def delete(self, path):
         '''Delete the underlying file for this object.'''
-        try: os.unlink(path)
-        except: pass
-        
+        try:
+            os.unlink(path)
+        except:
+            pass
+
     def writeDuration(self, duration):
-        if _debug: print 'writing duration', duration
+        if _debug:
+            print 'writing duration', duration
         output = amf.BytesIO()
-        amfWriter = amf.AMF0(output) # TODO: use AMF3 if needed
+        amfWriter = amf.AMF0(output)  # TODO: use AMF3 if needed
         amfWriter.write('onMetaData')
         amfWriter.write({"duration": duration, "videocodecid": 2})
-        output.seek(0); data = output.read()
+        output.seek(0)
+        data = output.read()
         length, ts = len(data), 0
-        data = struct.pack('>BBHBHB', Message.DATA, (length >> 16) & 0xff, length & 0x0ffff, (ts >> 16) & 0xff, ts & 0x0ffff, (ts >> 24) & 0xff) + '\x00\x00\x00' +  data
+        data = struct.pack('>BBHBHB', Message.DATA, (length >> 16) & 0xff, length & 0x0ffff, (
+            ts >> 16) & 0xff, ts & 0x0ffff, (ts >> 24) & 0xff) + '\x00\x00\x00' + data
         data += struct.pack('>I', len(data))
         lastpos = self.fp.tell()
-        if lastpos != 13: self.fp.seek(13, os.SEEK_SET)
+        if lastpos != 13:
+            self.fp.seek(13, os.SEEK_SET)
         self.fp.write(data)
-        if lastpos != 13: self.fp.seek(lastpos, os.SEEK_SET)
-        
+        if lastpos != 13:
+            self.fp.seek(lastpos, os.SEEK_SET)
+
     def write(self, message):
         '''Write a message to the file, assuming it was opened for writing or appending.'''
 #        if message.type == Message.VIDEO:
@@ -713,194 +826,240 @@ class FLV(object):
 #        elif not hasattr(self, "videostarted"): return
         if message.type == Message.AUDIO or message.type == Message.VIDEO:
             length, ts = message.size, message.time
-            #if _debug: print 'FLV.write()', message.type, ts
-            if self.tsr0 is None: self.tsr0 = ts - self.tsr1
+            # if _debug: print 'FLV.write()', message.type, ts
+            if self.tsr0 is None:
+                self.tsr0 = ts - self.tsr1
             self.tsr, ts = ts, ts - self.tsr0
             # if message.type == Message.AUDIO: print 'w', message.type, ts
-            data = struct.pack('>BBHBHB', message.type, (length >> 16) & 0xff, length & 0x0ffff, (ts >> 16) & 0xff, ts & 0x0ffff, (ts >> 24) & 0xff) + '\x00\x00\x00' +  message.data
+            data = struct.pack('>BBHBHB', message.type, (length >> 16) & 0xff, length & 0x0ffff, (
+                ts >> 16) & 0xff, ts & 0x0ffff, (ts >> 24) & 0xff) + '\x00\x00\x00' + message.data
             data += struct.pack('>I', len(data))
             self.fp.write(data)
-    
+
     def reader(self, stream):
         '''A generator to periodically read the file and dispatch them to the stream. The supplied stream
         object must have a send(Message) method and id and client properties.'''
-        if _debug: print 'reader started'
+        if _debug:
+            print 'reader started'
         yield
         try:
             while self.fp is not None:
                 bytes = self.fp.read(11)
                 if len(bytes) == 0:
-                    try: tm = stream.client.relativeTime
-                    except: tm = 0
-                    response = Command(name='onStatus', id=stream.id, tm=tm, args=[amf.Object(level='status',code='NetStream.Play.Stop', description='File ended', details=None)])
+                    try:
+                        tm = stream.client.relativeTime
+                    except:
+                        tm = 0
+                    response = Command(name='onStatus', id=stream.id, tm=tm, args=[amf.Object(
+                        level='status', code='NetStream.Play.Stop', description='File ended', details=None)])
                     yield stream.send(response.toMessage())
                     break
-                type, len0, len1, ts0, ts1, ts2, sid0, sid1 = struct.unpack('>BBHBHBBH', bytes)
-                length = (len0 << 16) | len1; ts = (ts0 << 16) | (ts1 & 0x0ffff) | (ts2 << 24)
-                body = self.fp.read(length); ptagsize, = struct.unpack('>I', self.fp.read(4))
-                if ptagsize != (length+11): 
-                    if _debug: print 'invalid previous tag-size found:', ptagsize, '!=', (length+11),'ignored.'
-                if stream is None or stream.client is None: break # if it is closed
+                type, len0, len1, ts0, ts1, ts2, sid0, sid1 = struct.unpack(
+                    '>BBHBHBBH', bytes)
+                length = (len0 << 16) | len1
+                ts = (ts0 << 16) | (ts1 & 0x0ffff) | (ts2 << 24)
+                body = self.fp.read(length)
+                ptagsize, = struct.unpack('>I', self.fp.read(4))
+                if ptagsize != (length+11):
+                    if _debug:
+                        print 'invalid previous tag-size found:', ptagsize, '!=', (length+11), 'ignored.'
+                if stream is None or stream.client is None:
+                    break  # if it is closed
                 #hdr = Header(3 if type == Message.AUDIO else 4, ts if ts < 0xffffff else 0xffffff, length, type, stream.id)
                 hdr = Header(0, ts, length, type, stream.id)
                 msg = Message(hdr, body)
                 # if _debug: print 'FLV.read() length=', length, 'hdr=', hdr
                 # if hdr.type == Message.AUDIO: print 'r', hdr.type, hdr.time
-                if type == Message.DATA: # metadata
-                    amfReader = amf.AMF0(body) # TODO: use AMF3 if needed
+                if type == Message.DATA:  # metadata
+                    amfReader = amf.AMF0(body)  # TODO: use AMF3 if needed
                     name = amfReader.read()
                     obj = amfReader.read()
-                    if _debug: print 'FLV.read()', name, repr(obj)
+                    if _debug:
+                        print 'FLV.read()', name, repr(obj)
                 yield stream.send(msg)
-                if ts > self.tsp: 
+                if ts > self.tsp:
                     diff, self.tsp = ts - self.tsp, ts
-                    if _debug: print 'FLV.read() sleep', diff
+                    if _debug:
+                        print 'FLV.read() sleep', diff
                     yield multitask.sleep(diff / 1000.0)
-        except StopIteration: pass
-        except: 
-            if _debug: print 'closing the reader', (sys and sys.exc_info() or None)
-            if self.fp is not None: 
-                try: self.fp.close()
-                except: pass
+        except StopIteration:
+            pass
+        except:
+            if _debug:
+                print 'closing the reader', (sys and sys.exc_info() or None)
+            if self.fp is not None:
+                try:
+                    self.fp.close()
+                except:
+                    pass
                 self.fp = None
-            
+
     def seek(self, offset):
         '''For file reader, try seek to the given time. The offset is in millisec'''
         if self.type == 'read':
-            if _debug: print 'FLV.seek() offset=', offset, 'current tsp=', self.tsp
+            if _debug:
+                print 'FLV.seek() offset=', offset, 'current tsp=', self.tsp
             self.fp.seek(0, os.SEEK_SET)
-            magic, version, flags, length = struct.unpack('!3sBBI', self.fp.read(9))
-            if length > 9: self.fp.seek(length-9, os.SEEK_CUR)
-            self.fp.seek(4, os.SEEK_CUR) # ignore first previous tag size
+            magic, version, flags, length = struct.unpack(
+                '!3sBBI', self.fp.read(9))
+            if length > 9:
+                self.fp.seek(length-9, os.SEEK_CUR)
+            self.fp.seek(4, os.SEEK_CUR)  # ignore first previous tag size
             self.tsp, ts = int(offset), 0
             while self.tsp > 0 and ts < self.tsp:
                 bytes = self.fp.read(11)
-                if not bytes: break
-                type, len0, len1, ts0, ts1, ts2, sid0, sid1 = struct.unpack('>BBHBHBBH', bytes)
-                length = (len0 << 16) | len1; ts = (ts0 << 16) | (ts1 & 0x0ffff) | (ts2 << 24)
+                if not bytes:
+                    break
+                type, len0, len1, ts0, ts1, ts2, sid0, sid1 = struct.unpack(
+                    '>BBHBHBBH', bytes)
+                length = (len0 << 16) | len1
+                ts = (ts0 << 16) | (ts1 & 0x0ffff) | (ts2 << 24)
                 self.fp.seek(length, os.SEEK_CUR)
                 ptagsize, = struct.unpack('>I', self.fp.read(4))
-                if ptagsize != (length+11): break
-            if _debug: print 'FLV.seek() new ts=', ts, 'tell', self.fp.tell()
-                
-        
+                if ptagsize != (length+11):
+                    break
+            if _debug:
+                print 'FLV.seek() new ts=', ts, 'tell', self.fp.tell()
+
+
 class Stream(object):
     '''The stream object that is used for RTMP stream.'''
-    count = 0;
+    count = 0
+
     def __init__(self, client):
         self.client, self.id, self.name = client, 0, ''
-        self.recordfile = self.playfile = None # so that it doesn't complain about missing attribute
+        # so that it doesn't complain about missing attribute
+        self.recordfile = self.playfile = None
         self.queue = multitask.Queue()
-        self._name = 'Stream[' + str(Stream.count) + ']'; Stream.count += 1
-        if _debug: print self, 'created'
-        
+        self._name = 'Stream[' + str(Stream.count) + ']'
+        Stream.count += 1
+        if _debug:
+            print self, 'created'
+
     def close(self):
-        if _debug: print self, 'closing'
-        if self.recordfile is not None: self.recordfile.close(); self.recordfile = None
-        if self.playfile is not None: self.playfile.close(); self.playfile = None
-        self.client = None # to clear the reference
+        if _debug:
+            print self, 'closing'
+        if self.recordfile is not None:
+            self.recordfile.close()
+            self.recordfile = None
+        if self.playfile is not None:
+            self.playfile.close()
+            self.playfile = None
+        self.client = None  # to clear the reference
         pass
-    
+
     def __repr__(self):
-        return self._name;
-    
+        return self._name
+
     def recv(self):
         '''Generator to receive new Message on this stream, or None if stream is closed.'''
         return self.queue.get()
-    
+
     def send(self, msg):
         '''Method to send a Message or Command on this stream.'''
         if isinstance(msg, Command):
             msg = msg.toMessage()
         msg.streamId = self.id
         # if _debug: print self,'send'
-        if self.client is not None: yield self.client.writeMessage(msg)
-        
+        if self.client is not None:
+            yield self.client.writeMessage(msg)
+
+
 class Client(Protocol):
     '''The client object represents a single connected client to the server.'''
+
     def __init__(self, sock, server):
         Protocol.__init__(self, sock)
         self.server, self.agent, self.streams, self._nextCallId, self._nextStreamId, self.objectEncoding = \
-          server,      None,         {},           2,                1,                  0.0
-        self.queue = multitask.Queue() # receive queue used by application
-        multitask.add(self.parse()); multitask.add(self.write())
+            server,      None,         {},           2,                1,                  0.0
+        self.queue = multitask.Queue()  # receive queue used by application
+        multitask.add(self.parse())
+        multitask.add(self.write())
 
     def recv(self):
         '''Generator to receive new Message (msg, arg) on this stream, or (None,None) if stream is closed.'''
         return self.queue.get()
-    
+
     def connectionClosed(self):
         '''Called when the client drops the connection'''
-        if _debug: 'Client.connectionClosed'
+        if _debug:
+            'Client.connectionClosed'
         yield self.writeMessage(None)
-        yield self.queue.put((None,None))
-            
+        yield self.queue.put((None, None))
+
     def messageReceived(self, msg):
         if (msg.type == Message.RPC or msg.type == Message.RPC3) and msg.streamId == 0:
             cmd = Command.fromMessage(msg)
             # if _debug: print 'rtmp.Client.messageReceived cmd=', cmd
             if cmd.name == 'connect':
                 self.agent = cmd.cmdData
-                if _debug: print 'connect', ', '.join(['%s=%r'%(x, getattr(self.agent, x)) for x in 'app flashVer swfUrl tcUrl fpad capabilities audioCodecs videoCodecs videoFunction pageUrl objectEncoding'.split() if hasattr(self.agent, x)])
-                self.objectEncoding = self.agent.objectEncoding if hasattr(self.agent, 'objectEncoding') else 0.0
-                yield self.server.queue.put((self, cmd.args)) # new connection
+                if _debug:
+                    print 'connect', ', '.join(['%s=%r' % (x, getattr(self.agent, x)) for x in 'app flashVer swfUrl tcUrl fpad capabilities audioCodecs videoCodecs videoFunction pageUrl objectEncoding'.split() if hasattr(self.agent, x)])
+                self.objectEncoding = self.agent.objectEncoding if hasattr(
+                    self.agent, 'objectEncoding') else 0.0
+                yield self.server.queue.put((self, cmd.args))  # new connection
             elif cmd.name == 'createStream':
-                response = Command(name='_result', id=cmd.id, tm=self.relativeTime, type=self.rpc, args=[self._nextStreamId])
+                response = Command(name='_result', id=cmd.id, tm=self.relativeTime, type=self.rpc, args=[
+                                   self._nextStreamId])
                 yield self.writeMessage(response.toMessage())
-                
-                stream = Stream(self) # create a stream object
+
+                stream = Stream(self)  # create a stream object
                 stream.id = self._nextStreamId
                 self.streams[self._nextStreamId] = stream
                 self._nextStreamId += 1
 
-                yield self.queue.put(('stream', stream)) # also notify others of our new stream
+                # also notify others of our new stream
+                yield self.queue.put(('stream', stream))
             elif cmd.name == 'closeStream':
                 assert msg.streamId in self.streams
-                yield self.streams[msg.streamId].queue.put(None) # notify closing to others
+                # notify closing to others
+                yield self.streams[msg.streamId].queue.put(None)
                 del self.streams[msg.streamId]
             else:
                 # if _debug: print 'Client.messageReceived cmd=', cmd
-                yield self.queue.put(('command', cmd)) # RPC call
-        else: # this has to be a message on the stream
+                yield self.queue.put(('command', cmd))  # RPC call
+        else:  # this has to be a message on the stream
             assert msg.streamId != 0
             assert msg.streamId in self.streams
             # if _debug: print self.streams[msg.streamId], 'recv'
             stream = self.streams[msg.streamId]
-            if not stream.client: stream.client = self 
-            yield stream.queue.put(msg) # give it to stream
+            if not stream.client:
+                stream.client = self
+            yield stream.queue.put(msg)  # give it to stream
 
     @property
     def rpc(self):
         # TODO: reverting r141 since it causes exception in setting self.rpc
         return Message.RPC if self.objectEncoding == 0.0 else Message.RPC3
-    
+
     def accept(self):
         '''Method to accept an incoming client.'''
         response = Command()
         response.id, response.name, response.type = 1, '_result', self.rpc
-        if _debug: print 'Client.accept() objectEncoding=', self.objectEncoding
+        if _debug:
+            print 'Client.accept() objectEncoding=', self.objectEncoding
         arg = amf.Object(level='status', code='NetConnection.Connect.Success',
                          description='Connection succeeded.', fmsVer='rtmplite/8,2')
         if hasattr(self.agent, 'objectEncoding'):
             arg.objectEncoding, arg.details = self.objectEncoding, None
         response.setArg(arg)
         yield self.writeMessage(response.toMessage())
-            
+
     def rejectConnection(self, reason=''):
         '''Method to reject an incoming client.'''
         response = Command()
         response.id, response.name, response.type = 1, '_error', self.rpc
         response.setArg(amf.Object(level='status', code='NetConnection.Connect.Rejected',
-                        description=reason, fmsVer='rtmplite/8,2', details=None))
+                                   description=reason, fmsVer='rtmplite/8,2', details=None))
         yield self.writeMessage(response.toMessage())
-            
+
     def redirectConnection(self, url, reason='Connection failed'):
         '''Method to redirect an incoming client to the given url.'''
         response = Command()
         response.id, response.name, response.type = 1, '_error', self.rpc
         extra = dict(code=302, redirect=url)
         response.setArg(amf.Object(level='status', code='NetConnection.Connect.Rejected',
-                        description=reason, fmsVer='rtmplite/8,2', details=None, ex=extra))
+                                   description=reason, fmsVer='rtmplite/8,2', details=None, ex=extra))
         yield self.writeMessage(response.toMessage())
 
     def call(self, method, *args):
@@ -909,9 +1068,10 @@ class Client(Protocol):
         cmd.id, cmd.time, cmd.name, cmd.type = self._nextCallId, self.relativeTime, method, self.rpc
         cmd.args, cmd.cmdData = args, None
         self._nextCallId += 1
-        if _debug: print 'Client.call method=', method, 'args=', args, ' msg=', cmd.toMessage()
+        if _debug:
+            print 'Client.call method=', method, 'args=', args, ' msg=', cmd.toMessage()
         yield self.writeMessage(cmd.toMessage())
-            
+
     def createStream(self):
         ''' Create a stream on the server side'''
         stream = Stream(self)
@@ -923,6 +1083,7 @@ class Client(Protocol):
 
 class Server(object):
     '''A RTMP server listens for incoming connections and informs the app.'''
+
     def __init__(self, sock):
         '''Create an RTMP server on the given bound TCP socket. The server will terminate
         when the socket is disconnected, or some other error occurs in listening.'''
@@ -934,74 +1095,115 @@ class Server(object):
         '''Generator to wait for incoming client connections on this server and return
         (client, args) or (None, None) if the socket is closed or some error.'''
         return self.queue.get()
-        
+
     def run(self):
         try:
             while True:
-                sock, remote = (yield multitask.accept(self.sock))  # receive client TCP
+                # receive client TCP
+                sock, remote = (yield multitask.accept(self.sock))
                 if sock == None:
-                    if _debug: print 'rtmp.Server accept(sock) returned None.' 
+                    if _debug:
+                        print 'rtmp.Server accept(sock) returned None.'
                     break
-                if _debug: print 'connection received from', remote
-                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1) # make it non-block
+                if _debug:
+                    print 'connection received from', remote
+                # make it non-block
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
                 client = Client(sock, self)
-        except GeneratorExit: pass # terminate
-        except: 
-            if _debug: print 'rtmp.Server exception ', (sys and sys.exc_info() or None)
-        
+        except GeneratorExit:
+            pass  # terminate
+        except:
+            if _debug:
+                print 'rtmp.Server exception ', (sys and sys.exc_info() or None)
+
         if (self.sock):
-            try: self.sock.close(); self.sock = None
-            except: pass
+            try:
+                self.sock.close()
+                self.sock = None
+            except:
+                pass
         if (self.queue):
             yield self.queue.put((None, None))
             self.queue = None
 
+
 class App(object):
     '''An application instance containing any number of streams. Except for constructor all methods are generators.'''
     count = 0
+
     def __init__(self):
-        self.name = str(self.__class__.__name__) + '[' + str(App.count) + ']'; App.count += 1
-        self.players, self.publishers, self._clients = {}, {}, [] # Streams indexed by stream name, and list of clients
-        if _debug: print self.name, 'created'
+        self.name = str(self.__class__.__name__) + '[' + str(App.count) + ']'
+        App.count += 1
+        # Streams indexed by stream name, and list of clients
+        self.players, self.publishers, self._clients = {}, {}, []
+        if _debug:
+            print self.name, 'created'
+
     def __del__(self):
-        if _debug: print self.name, 'destroyed'
+        if _debug:
+            print self.name, 'destroyed'
+
     @property
     def clients(self):
         '''everytime this property is accessed it returns a new list of clients connected to this instance.'''
         return self._clients[1:] if self._clients is not None else []
+
     def onConnect(self, client, *args):
-        if _debug: print self.name, 'onConnect', client.path
+        if _debug:
+            print self.name, 'onConnect', client.path
         return True
+
     def onDisconnect(self, client):
-        if _debug: print self.name, 'onDisconnect', client.path
+        if _debug:
+            print self.name, 'onDisconnect', client.path
+
     def onPublish(self, client, stream):
-        if _debug: print self.name, 'onPublish', client.path, stream.name
+        if _debug:
+            print self.name, 'onPublish', client.path, stream.name
+
     def onClose(self, client, stream):
-        if _debug: print self.name, 'onClose', client.path, stream.name
+        if _debug:
+            print self.name, 'onClose', client.path, stream.name
+
     def onPlay(self, client, stream):
-        if _debug: print self.name, 'onPlay', client.path, stream.name
+        if _debug:
+            print self.name, 'onPlay', client.path, stream.name
+
     def onStop(self, client, stream):
-        if _debug: print self.name, 'onStop', client.path, stream.name
+        if _debug:
+            print self.name, 'onStop', client.path, stream.name
+
     def onCommand(self, client, cmd, *args):
-        if _debug: print self.name, 'onCommand', cmd, args
+        if _debug:
+            print self.name, 'onCommand', cmd, args
+
     def onStatus(self, client, info):
-        if _debug: print self.name, 'onStatus', info
+        if _debug:
+            print self.name, 'onStatus', info
+
     def onResult(self, client, result):
-        if _debug: print self.name, 'onResult', result
-    def onPublishData(self, client, stream, message): # this is invoked every time some media packet is received from published stream.
-        return True # should return True so that the data is actually published in that stream
+        if _debug:
+            print self.name, 'onResult', result
+
+    # this is invoked every time some media packet is received from published stream.
+    def onPublishData(self, client, stream, message):
+        return True  # should return True so that the data is actually published in that stream
+
     def onPlayData(self, client, stream, message):
-        return True # should return True so that data will be actually played in that stream
+        return True  # should return True so that data will be actually played in that stream
+
     def getfile(self, path, name, root, mode):
         if mode == 'play':
             path = getfilename(path, name, root)
-            if not os.path.exists(path): return None
+            if not os.path.exists(path):
+                return None
             return FLV().open(path)
         elif mode in ('record', 'append'):
             path = getfilename(path, name, root)
             return FLV().open(path, mode)
 #        elif stream.mode == 'live': FLV().delete(path) # TODO: this is commented out to avoid accidental delete
         return None
+
 
 class Wirecast(App):
     '''A wrapper around App to workaround with wirecast publisher which does not send AVC seq periodically. It defines new stream variables
@@ -1011,167 +1213,212 @@ class Wirecast(App):
     it detects AVC seq it sets avcIntra so that it is not explicitly sent. This is the case with Flash Player publisher. When onPlayData for video,
     if it detects avcIntra is not set, it discards the packet until AVC NALU or seq is received. If NALU is received but previous seq is not received
     it uses the publisher's avcSeq message to send before this NALU if found.'''
+
     def __init__(self):
         App.__init__(self)
 
     def onPublish(self, client, stream):
         App.onPublish(self, client, stream)
-        if not hasattr(stream, 'metaData'): stream.metaData = None
-        if not hasattr(stream, 'avcSeq'): stream.avcSeq = None
-        
+        if not hasattr(stream, 'metaData'):
+            stream.metaData = None
+        if not hasattr(stream, 'avcSeq'):
+            stream.avcSeq = None
+
     def onPlay(self, client, stream):
         App.onPlay(self, client, stream)
-        if not hasattr(stream, 'avcIntra'): stream.avcIntra = False
+        if not hasattr(stream, 'avcIntra'):
+            stream.avcIntra = False
         publisher = self.publishers.get(stream.name, None)
-        if publisher and publisher.metaData: # send published meta data to this player joining late
+        if publisher and publisher.metaData:  # send published meta data to this player joining late
             multitask.add(stream.send(publisher.metaData.dup()))
-    
+
     def onPublishData(self, client, stream, message):
-        if message.type == Message.DATA and not stream.metaData: # store the first meta data on this published stream for late joining players
+        # store the first meta data on this published stream for late joining players
+        if message.type == Message.DATA and not stream.metaData:
             stream.metaData = message.dup()
-        if message.type == Message.VIDEO and message.data[:2] == '\x17\x00': # H264Avc intra + seq, store it
+        # H264Avc intra + seq, store it
+        if message.type == Message.VIDEO and message.data[:2] == '\x17\x00':
             stream.avcSeq = message.dup()
         return True
 
     def onPlayData(self, client, stream, message):
-        if message.type == Message.VIDEO: # only video packets need special handling
-            if message.data[:2] == '\x17\x00': # intra+seq is being sent, possibly by Flash Player publisher.
+        if message.type == Message.VIDEO:  # only video packets need special handling
+            # intra+seq is being sent, possibly by Flash Player publisher.
+            if message.data[:2] == '\x17\x00':
                 stream.avcIntra = True
             elif not stream.avcIntra:  # intra frame hasn't been sent yet.
-                if message.data[:2] == '\x17\x01': # intra+nalu is being sent, possibly by wirecast publisher.
+                # intra+nalu is being sent, possibly by wirecast publisher.
+                if message.data[:2] == '\x17\x01':
                     publisher = self.publishers.get(stream.name, None)
-                    if publisher and publisher.avcSeq: # if a publisher exists
+                    if publisher and publisher.avcSeq:  # if a publisher exists
                         def sendboth(stream, msgs):
                             stream.avcIntra = True
-                            for msg in msgs: yield stream.send(msg)
-                        multitask.add(sendboth(stream, [publisher.avcSeq.dup(), message]))
-                        return False # so that caller doesn't send it again
-                return False # drop until next intra video is sent
+                            for msg in msgs:
+                                yield stream.send(msg)
+                        multitask.add(
+                            sendboth(stream, [publisher.avcSeq.dup(), message]))
+                        return False  # so that caller doesn't send it again
+                return False  # drop until next intra video is sent
         return True
+
 
 class FlashServer(object):
     '''A RTMP server to record and stream Flash video.'''
+
     def __init__(self):
         '''Construct a new FlashServer. It initializes the local members.'''
-        self.sock = self.server = None;
-        self.apps = dict({'*': App, 'wirecast': Wirecast}) # supported applications: * means any as in {'*': App}
-        self.clients = dict()  # list of clients indexed by scope. First item in list is app instance.
-        self.root = '';
-        
+        self.sock = self.server = None
+        # supported applications: * means any as in {'*': App}
+        self.apps = dict({'*': App, 'wirecast': Wirecast})
+        # list of clients indexed by scope. First item in list is app instance.
+        self.clients = dict()
+        self.root = ''
+
     def start(self, host='0.0.0.0', port=1935):
         '''This should be used to start listening for RTMP connections on the given port, which defaults to 1935.'''
         if not self.server:
             sock = self.sock = socket.socket(type=socket.SOCK_STREAM)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.bind((host, port))
-            if _debug: print 'listening on ', sock.getsockname()
+            if _debug:
+                print 'listening on ', sock.getsockname()
             sock.listen(5)
-            server = self.server = Server(sock) # start rtmp server on that socket
+            # start rtmp server on that socket
+            server = self.server = Server(sock)
             multitask.add(self.serverlistener())
-    
+
     def stop(self):
-        if _debug: print 'stopping Flash server'
+        if _debug:
+            print 'stopping Flash server'
         if self.server and self.sock:
-            try: self.sock.close(); self.sock = None
-            except: pass
+            try:
+                self.sock.close()
+                self.sock = None
+            except:
+                pass
         self.server = None
-        
+
     def serverlistener(self):
         '''Server listener (generator). It accepts all connections and invokes client listener'''
         try:
             while True:  # main loop to receive new connections on the server
-                client, args = (yield self.server.recv()) # receive an incoming client connection.
+                # receive an incoming client connection.
+                client, args = (yield self.server.recv())
                 # TODO: we should reject non-localhost client connections.
                 if not client:                # if the server aborted abnormally,
-                    break                     #    hence close the listener.
-                if _debug: print 'client connection received', client, args
+                    break  # hence close the listener.
+                if _debug:
+                    print 'client connection received', client, args
                 if client.objectEncoding != 0 and client.objectEncoding != 3:
-                #if client.objectEncoding != 0:
+                    # if client.objectEncoding != 0:
                     yield client.rejectConnection(reason='Unsupported encoding ' + str(client.objectEncoding) + '. Please use NetConnection.defaultObjectEncoding=ObjectEncoding.AMF0')
                     yield client.connectionClosed()
                 else:
-                    client.path = str(client.agent.app) if hasattr(client.agent, 'app') else str(client.agent['app']) if isinstance(client.agent, dict) else None
+                    client.path = str(client.agent.app) if hasattr(client.agent, 'app') else str(
+                        client.agent['app']) if isinstance(client.agent, dict) else None
                     if not client.path:
                         yield client.rejectConnection(reason='Missing app path')
                         break
                     name, ignore, scope = client.path.partition('/')
                     if '*' not in self.apps and name not in self.apps:
                         yield client.rejectConnection(reason='Application not found: ' + name)
-                    else: # create application instance as needed and add in our list
-                        if _debug: print 'name=', name, 'name in apps', str(name in self.apps)
-                        app = self.apps[name] if name in self.apps else self.apps['*'] # application class
-                        if client.path in self.clients: inst = self.clients[client.path][0]
-                        else: inst = app()
-                        
+                    else:  # create application instance as needed and add in our list
+                        if _debug:
+                            print 'name=', name, 'name in apps', str(name in self.apps)
+                        # application class
+                        app = self.apps[name] if name in self.apps else self.apps['*']
+                        if client.path in self.clients:
+                            inst = self.clients[client.path][0]
+                        else:
+                            inst = app()
+
                         win_ack = Message()
-                        win_ack.time, win_ack.type, win_ack.data = client.relativeTime, Message.WIN_ACK_SIZE, struct.pack('>L', client.writeWinSize)
+                        win_ack.time, win_ack.type, win_ack.data = client.relativeTime, Message.WIN_ACK_SIZE, struct.pack(
+                            '>L', client.writeWinSize)
                         yield client.writeMessage(win_ack)
-                        
+
 #                        set_peer_bw = Message()
 #                        set_peer_bw.time, set_peer_bw.type, set_peer_bw.data = client.relativeTime, Message.SET_PEER_BW, struct.pack('>LB', client.writeWinSize, 1)
 #                        client.writeMessage(set_peer_bw)
-                        
-                        try: 
+
+                        try:
                             result = inst.onConnect(client, *args)
-                        except: 
-                            if _debug: print sys.exc_info()
-                            yield client.rejectConnection(reason='Exception on onConnect'); 
+                        except:
+                            if _debug:
+                                print sys.exc_info()
+                            yield client.rejectConnection(reason='Exception on onConnect')
                             continue
                         if result is True or result is None:
-                            if client.path not in self.clients: 
-                                self.clients[client.path] = [inst]; inst._clients=self.clients[client.path]
+                            if client.path not in self.clients:
+                                self.clients[client.path] = [inst]
+                                inst._clients = self.clients[client.path]
                             self.clients[client.path].append(client)
                             if result is True:
-                                yield client.accept() # TODO: else how to kill this task when rejectConnection() later
-                            multitask.add(self.clientlistener(client)) # receive messages from client.
-                        else: 
+                                yield client.accept()  # TODO: else how to kill this task when rejectConnection() later
+                            # receive messages from client.
+                            multitask.add(self.clientlistener(client))
+                        else:
                             yield client.rejectConnection(reason='Rejected in onConnect')
-        except GeneratorExit: pass # terminate
-        except StopIteration: raise
-        except: 
-            if _debug: print 'serverlistener exception', traceback.print_exc()
-            
+        except GeneratorExit:
+            pass  # terminate
+        except StopIteration:
+            raise
+        except:
+            if _debug:
+                print 'serverlistener exception', traceback.print_exc()
+
     def clientlistener(self, client):
         '''Client listener (generator). It receives a command and invokes client handler, or receives a new stream and invokes streamlistener.'''
         try:
             while True:
-                msg, arg = (yield client.recv())   # receive new message from client
+                # receive new message from client
+                msg, arg = (yield client.recv())
                 if not msg:                   # if the client disconnected,
-                    if _debug: print 'connection closed from client'
-                    break                     #    come out of listening loop.
+                    if _debug:
+                        print 'connection closed from client'
+                    break  # come out of listening loop.
                 if msg == 'command':          # handle a new command
                     multitask.add(self.clienthandler(client, arg))
-                elif msg == 'stream':         # a new stream is created, handle the stream.
+                # a new stream is created, handle the stream.
+                elif msg == 'stream':
                     arg.client = client
                     multitask.add(self.streamlistener(arg))
-        except StopIteration: raise
+        except StopIteration:
+            raise
         except:
-            if _debug: print 'clientlistener exception', (sys and sys.exc_info() or None)
-        
+            if _debug:
+                print 'clientlistener exception', (sys and sys.exc_info() or None)
+
         try:
             # client is disconnected, clear our state for application instance.
-            if _debug: print 'cleaning up client', client.path
+            if _debug:
+                print 'cleaning up client', client.path
             inst = None
             if client.path in self.clients:
                 inst = self.clients[client.path][0]
                 self.clients[client.path].remove(client)
-            for stream in client.streams.values(): # for all streams of this client
+            for stream in client.streams.values():  # for all streams of this client
                 self.closehandler(stream)
-            client.streams.clear() # and clear the collection of streams
-            if client.path in self.clients and len(self.clients[client.path]) == 1: # no more clients left, delete the instance.
-                if _debug: print 'removing the application instance'
+            client.streams.clear()  # and clear the collection of streams
+            # no more clients left, delete the instance.
+            if client.path in self.clients and len(self.clients[client.path]) == 1:
+                if _debug:
+                    print 'removing the application instance'
                 inst = self.clients[client.path][0]
                 inst._clients = None
                 del self.clients[client.path]
-            if inst is not None: inst.onDisconnect(client)
-        except: 
-            if _debug: print 'clientlistener exception', (sys and sys.exc_info() or None)
-            
+            if inst is not None:
+                inst.onDisconnect(client)
+        except:
+            if _debug:
+                print 'clientlistener exception', (sys and sys.exc_info() or None)
+
     def closehandler(self, stream):
         '''A stream is closed explicitly when a closeStream command is received from given client.'''
         if stream.client is not None:
             inst = self.clients[stream.client.path][0]
-            if stream.name in inst.publishers and inst.publishers[stream.name] == stream: # clear the published stream
+            # clear the published stream
+            if stream.name in inst.publishers and inst.publishers[stream.name] == stream:
                 inst.onClose(stream.client, stream)
                 del inst.publishers[stream.name]
             if stream.name in inst.players and stream in inst.players[stream.name]:
@@ -1180,7 +1427,7 @@ class FlashServer(object):
                 if len(inst.players[stream.name]) == 0:
                     del inst.players[stream.name]
             stream.close()
-        
+
     def clienthandler(self, client, cmd):
         '''A generator to handle a single command on the client.'''
         inst = self.clients[client.path][0]
@@ -1196,36 +1443,41 @@ class FlashServer(object):
                 try:
                     result = inst.onCommand(client, cmd.name, *cmd.args)
                 except:
-                    if _debug: print 'Client.call exception', (sys and sys.exc_info() or None) 
+                    if _debug:
+                        print 'Client.call exception', (sys and sys.exc_info() or None)
                     code = '_error'
                 args = (result,) if result is not None else dict()
                 res.id, res.time, res.name, res.type = cmd.id, client.relativeTime, code, client.rpc
                 res.args, res.cmdData = args, None
-                if _debug: print 'Client.call method=', code, 'args=', args, ' msg=', res.toMessage()
+                if _debug:
+                    print 'Client.call method=', code, 'args=', args, ' msg=', res.toMessage()
                 yield client.writeMessage(res.toMessage())
         yield
-        
+
     def streamlistener(self, stream):
         '''Stream listener (generator). It receives stream message and invokes streamhandler.'''
         try:
-            stream.recordfile = None # so that it doesn't complain about missing attribute
+            stream.recordfile = None  # so that it doesn't complain about missing attribute
             while True:
                 msg = (yield stream.recv())
                 if not msg:
-                    if _debug: print 'stream closed'
+                    if _debug:
+                        print 'stream closed'
                     self.closehandler(stream)
                     break
                 # if _debug: msg
                 multitask.add(self.streamhandler(stream, msg))
-        except: 
-            if _debug: print 'streamlistener exception', (sys and sys.exc_info() or None)
-            
+        except:
+            if _debug:
+                print 'streamlistener exception', (sys and sys.exc_info() or None)
+
     def streamhandler(self, stream, message):
         '''A generator to handle a single message on the stream.'''
         try:
             if message.type == Message.RPC or message.type == Message.RPC3:
                 cmd = Command.fromMessage(message)
-                if _debug: print 'streamhandler received cmd=', cmd
+                if _debug:
+                    print 'streamhandler received cmd=', cmd
                 if cmd.name == 'publish':
                     yield self.publishhandler(stream, cmd)
                 elif cmd.name == 'play':
@@ -1233,33 +1485,44 @@ class FlashServer(object):
                 elif cmd.name == 'closeStream':
                     self.closehandler(stream)
                 elif cmd.name == 'seek':
-                    yield self.seekhandler(stream, cmd) 
-            else: # audio or video message
+                    yield self.seekhandler(stream, cmd)
+            else:  # audio or video message
                 yield self.mediahandler(stream, message)
-        except GeneratorExit: pass
-        except StopIteration: raise
-        except: 
-            if _debug: print 'exception in streamhandler', (sys and sys.exc_info())
-    
+        except GeneratorExit:
+            pass
+        except StopIteration:
+            raise
+        except:
+            if _debug:
+                print 'exception in streamhandler', (sys and sys.exc_info())
+
     def publishhandler(self, stream, cmd):
         '''A new stream is published. Store the information in the application instance.'''
         try:
-            stream.mode = 'live' if len(cmd.args) < 2 else cmd.args[1] # live, record, append
+            stream.mode = 'live' if len(
+                cmd.args) < 2 else cmd.args[1]  # live, record, append
             stream.name = cmd.args[0]
-            if _debug: print 'publishing stream=', stream.name, 'mode=', stream.mode
-            if stream.name and '?' in stream.name: stream.name = stream.name.partition('?')[0]
+            if _debug:
+                print 'publishing stream=', stream.name, 'mode=', stream.mode
+            if stream.name and '?' in stream.name:
+                stream.name = stream.name.partition('?')[0]
             inst = self.clients[stream.client.path][0]
             if (stream.name in inst.publishers):
                 raise ValueError, 'Stream name already in use'
-            inst.publishers[stream.name] = stream # store the client for publisher
+            # store the client for publisher
+            inst.publishers[stream.name] = stream
             inst.onPublish(stream.client, stream)
-            
-            stream.recordfile = inst.getfile(stream.client.path, stream.name, self.root, stream.mode)
-            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(level='status', code='NetStream.Publish.Start', description='', details=None)])
+
+            stream.recordfile = inst.getfile(
+                stream.client.path, stream.name, self.root, stream.mode)
+            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[
+                               amf.Object(level='status', code='NetStream.Publish.Start', description='', details=None)])
             yield stream.send(response)
-        except ValueError, E: # some error occurred. inform the app.
-            if _debug: print 'error in publishing stream', str(E)
-            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(level='error',code='NetStream.Publish.BadName',description=str(E),details=None)])
+        except ValueError, E:  # some error occurred. inform the app.
+            if _debug:
+                print 'error in publishing stream', str(E)
+            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(
+                level='error', code='NetStream.Publish.BadName', description=str(E), details=None)])
             yield stream.send(response)
 
     def playhandler(self, stream, cmd):
@@ -1267,66 +1530,82 @@ class FlashServer(object):
         try:
             inst = self.clients[stream.client.path][0]
             name = stream.name = cmd.args[0]  # store the stream's name
-            if stream.name and '?' in stream.name: name = stream.name = stream.name.partition('?')[0]
+            if stream.name and '?' in stream.name:
+                name = stream.name = stream.name.partition('?')[0]
             start = cmd.args[1] if len(cmd.args) >= 2 else -2
             if name not in inst.players:
-                inst.players[name] = [] # initialize the players for this stream name
-            if stream not in inst.players[name]: # store the stream as players of this name
+                # initialize the players for this stream name
+                inst.players[name] = []
+            # store the stream as players of this name
+            if stream not in inst.players[name]:
                 inst.players[name].append(stream)
             task = None
             if start >= 0 or start == -2 and name not in inst.publishers:
-                stream.playfile = inst.getfile(stream.client.path, stream.name, self.root, 'play')
+                stream.playfile = inst.getfile(
+                    stream.client.path, stream.name, self.root, 'play')
                 if stream.playfile:
-                    if start > 0: stream.playfile.seek(start)
+                    if start > 0:
+                        stream.playfile.seek(start)
                     task = stream.playfile.reader(stream)
-                elif start >= 0: raise ValueError, 'Stream name not found'
-            if _debug: print 'playing stream=', name, 'start=', start
+                elif start >= 0:
+                    raise ValueError, 'Stream name not found'
+            if _debug:
+                print 'playing stream=', name, 'start=', start
             inst.onPlay(stream.client, stream)
-            
+
             # Default chunk size is 128. It is pretty small when we stream high audio and video quality.
             # So, send the choosen chunk size to flash client.
             stream.client.writeChunkSize = Protocol.HIGH_WRITE_CHUNK_SIZE
-            m0 = Message() # SetChunkSize
-            m0.time, m0.type, m0.data = stream.client.relativeTime, Message.CHUNK_SIZE, struct.pack('>L', stream.client.writeChunkSize)
+            m0 = Message()  # SetChunkSize
+            m0.time, m0.type, m0.data = stream.client.relativeTime, Message.CHUNK_SIZE, struct.pack(
+                '>L', stream.client.writeChunkSize)
             yield stream.client.writeMessage(m0)
-            
+
 #            m1 = Message() # UserControl/StreamIsRecorded
 #            m1.time, m1.type, m1.data = stream.client.relativeTime, Message.USER_CONTROL, struct.pack('>HI', 4, stream.id)
 #            yield stream.client.writeMessage(m1)
-            
-            m2 = Message() # UserControl/StreamBegin
-            m2.time, m2.type, m2.data = stream.client.relativeTime, Message.USER_CONTROL, struct.pack('>HI', 0, stream.id)
+
+            m2 = Message()  # UserControl/StreamBegin
+            m2.time, m2.type, m2.data = stream.client.relativeTime, Message.USER_CONTROL, struct.pack(
+                '>HI', 0, stream.id)
             yield stream.client.writeMessage(m2)
-            
+
 #            response = Command(name='onStatus', id=cmd.id, args=[amf.Object(level='status',code='NetStream.Play.Reset', description=stream.name, details=None)])
 #            yield stream.send(response)
-            
-            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(level='status',code='NetStream.Play.Start', description=stream.name, details=None)])
+
+            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(
+                level='status', code='NetStream.Play.Start', description=stream.name, details=None)])
             yield stream.send(response)
-            
+
 #            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(level='status',code='NetStream.Play.PublishNotify', description=stream.name, details=None)])
 #            yield stream.send(response)
-            
-            if task is not None: multitask.add(task)
-        except ValueError, E: # some error occurred. inform the app.
-            if _debug: print 'error in playing stream', str(E)
-            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(level='error',code='NetStream.Play.StreamNotFound',description=str(E),details=None)])
+
+            if task is not None:
+                multitask.add(task)
+        except ValueError, E:  # some error occurred. inform the app.
+            if _debug:
+                print 'error in playing stream', str(E)
+            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(
+                level='error', code='NetStream.Play.StreamNotFound', description=str(E), details=None)])
             yield stream.send(response)
-            
+
     def seekhandler(self, stream, cmd):
         '''A stream is seeked to a new position. This is allowed only for play from a file.'''
         try:
             offset = cmd.args[0]
-            if stream.playfile is None or stream.playfile.type != 'read': 
+            if stream.playfile is None or stream.playfile.type != 'read':
                 raise ValueError, 'Stream is not seekable'
             stream.playfile.seek(offset)
-            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(level='status',code='NetStream.Seek.Notify', description=stream.name, details=None)])
+            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(
+                level='status', code='NetStream.Seek.Notify', description=stream.name, details=None)])
             yield stream.send(response)
-        except ValueError, E: # some error occurred. inform the app.
-            if _debug: print 'error in seeking stream', str(E)
-            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[amf.Object(level='error',code='NetStream.Seek.Failed',description=str(E),details=None)])
+        except ValueError, E:  # some error occurred. inform the app.
+            if _debug:
+                print 'error in seeking stream', str(E)
+            response = Command(name='onStatus', id=cmd.id, tm=stream.client.relativeTime, args=[
+                               amf.Object(level='error', code='NetStream.Seek.Failed', description=str(E), details=None)])
             yield stream.send(response)
-            
+
     def mediahandler(self, stream, message):
         '''Handle incoming media on the stream, by sending to other stream in this application instance.'''
         if stream.client is not None:
@@ -1334,7 +1613,7 @@ class FlashServer(object):
             result = inst.onPublishData(stream.client, stream, message)
             if result:
                 for s in (inst.players.get(stream.name, [])):
-                    #if _debug: print 'D', stream.name, s.name
+                    # if _debug: print 'D', stream.name, s.name
                     m = message.dup()
                     result = inst.onPlayData(s.client, s, m)
                     if result:
@@ -1342,23 +1621,30 @@ class FlashServer(object):
                 if stream.recordfile is not None:
                     stream.recordfile.write(message)
 
+
 # The main routine to start, run and stop the service
 if __name__ == '__main__':
     from optparse import OptionParser
     parser = OptionParser(version='SVN $Revision$, $Date$'.replace('$', ''))
-    parser.add_option('-i', '--host',    dest='host',    default='0.0.0.0', help="listening IP address. Default '0.0.0.0'")
-    parser.add_option('-p', '--port',    dest='port',    default=1935, type="int", help='listening port number. Default 1935')
-    parser.add_option('-r', '--root',    dest='root',    default='./',       help="document path prefix. Directory must end with /. Default './'")
-    parser.add_option('-d', '--verbose', dest='verbose', default=False, action='store_true', help='enable debug trace')
+    parser.add_option('-i', '--host',    dest='host',    default='0.0.0.0',
+                      help="listening IP address. Default '0.0.0.0'")
+    parser.add_option('-p', '--port',    dest='port',    default=1935,
+                      type="int", help='listening port number. Default 1935')
+    parser.add_option('-r', '--root',    dest='root',    default='./',
+                      help="document path prefix. Directory must end with /. Default './'")
+    parser.add_option('-d', '--verbose', dest='verbose', default=False,
+                      action='store_true', help='enable debug trace')
     (options, args) = parser.parse_args()
-    
+
     _debug = options.verbose
     try:
         agent = FlashServer()
         agent.root = options.root
         agent.start(options.host, options.port)
-        if _debug: print time.asctime(), 'Flash Server Starts - %s:%d' % (options.host, options.port)
+        if _debug:
+            print time.asctime(), 'Flash Server Starts - %s:%d' % (options.host, options.port)
         multitask.run()
     except KeyboardInterrupt:
         pass
-    if _debug: print time.asctime(), 'Flash Server Stops'
+    if _debug:
+        print time.asctime(), 'Flash Server Stops'

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -97,7 +97,7 @@ class SchedulerTest(unittest.TestCase):
         try:
             os.remove(FAKE_DB_PATH)
         # FIXME find an expected exception
-        except Exception:
+        except BaseException:
             pass
 
     def test_generate_asset_list_assets_should_be_y_and_x(self):

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -96,7 +96,8 @@ class SchedulerTest(unittest.TestCase):
         viewer.db_conn.close()
         try:
             os.remove(FAKE_DB_PATH)
-        except:
+        # FIXME find an expected exception
+        except Exception:
             pass
 
     def test_generate_asset_list_assets_should_be_y_and_x(self):

--- a/tests/updates_test.py
+++ b/tests/updates_test.py
@@ -34,7 +34,7 @@ class UpdateTest(unittest.TestCase):
     def test_if_sha_file_not_exists__is_up_to_date__should_return_false(self):
         self.assertEqual(server.is_up_to_date(), True)
 
-    def test_if_sha_file_not_equals_to_branch_hash__is_up_to_date__should_return_false(self):
+    def test_if_sha_file_not_equals_to_branch_hash__is_up_to_date__should_return_false(self):  # noqa
         with open(self.sha_file, 'w+') as f:
             f.write(fancy_sha)
         self.assertEqual(server.is_up_to_date(), False)
@@ -51,7 +51,7 @@ class UpdateTest(unittest.TestCase):
     @patch('viewer.req_get', side_effect=mocked_req_get)
     @patch('viewer.remote_branch_available', side_effect=lambda _: True)
     @patch('viewer.fetch_remote_hash', side_effect=lambda _: 'master')
-    def test_if_sha_file_is_empty__check_update__should_return_true(self, req_get, remote_branch_available, fetch_remote_hash):
+    def test_if_sha_file_is_empty__check_update__should_return_true(self, req_get, remote_branch_available, fetch_remote_hash):  # noqa
         with open(self.sha_file, 'w+') as f:
             pass
 

--- a/tests/viewer_test.py
+++ b/tests/viewer_test.py
@@ -113,7 +113,7 @@ class TestWatchdog(ViewerTestCase):
         try:
             os.remove(self.u.WATCHDOG_PATH)
         # FIXME find an expected exception
-        except Exception:
+        except BaseException:
             pass
         self.u.watchdog()
         self.assertEqual(os.path.exists(self.u.WATCHDOG_PATH), True)

--- a/tests/viewer_test.py
+++ b/tests/viewer_test.py
@@ -112,7 +112,8 @@ class TestWatchdog(ViewerTestCase):
     def test_watchdog_should_create_file_if_not_exists(self):
         try:
             os.remove(self.u.WATCHDOG_PATH)
-        except:
+        # FIXME find an expected exception
+        except Exception:
             pass
         self.u.watchdog()
         self.assertEqual(os.path.exists(self.u.WATCHDOG_PATH), True)

--- a/viewer.py
+++ b/viewer.py
@@ -9,8 +9,9 @@ from threading import Thread
 
 from mixpanel import Mixpanel, MixpanelException
 from netifaces import gateways
-# FIXME unused import (consider using flake8 to find these types of problems)
-# from requests import get as req_get
+# FIXME unused import here, but used in tests/updates_test.py
+# should we import requests in that file and @patch requests.get?
+from requests import get as req_get  # noqa
 from signal import signal, SIGUSR1
 from time import sleep
 import logging

--- a/viewer.py
+++ b/viewer.py
@@ -9,7 +9,7 @@ from threading import Thread
 
 from mixpanel import Mixpanel, MixpanelException
 from netifaces import gateways
-# FIXME unused import
+# FIXME unused import (consider using flake8 to find these types of problems)
 # from requests import get as req_get
 from signal import signal, SIGUSR1
 from time import sleep

--- a/viewer.py
+++ b/viewer.py
@@ -196,7 +196,7 @@ class Scheduler(object):
         try:
             return path.getmtime(settings['database'])
         # FIXME, this is really just as bad as a bare except statement
-        except Exception:
+        except BaseException:
             return 0
 
 
@@ -495,6 +495,6 @@ if __name__ == "__main__":
     try:
         main()
     # FIXME, this is really just as bad as a bare except statement
-    except Exception:
+    except BaseException:
         logging.exception("Viewer crashed.")
         raise


### PR DESCRIPTION
It seems that pep8 has been renamed to pycodestyle.  Also, pycodestyle seems to be 
a little more nitpicky than pep8, but using pep8 is deprecated.
https://pep8.readthedocs.io/en/release-1.7.x/

I started this branch upon encountering the ugly code in rtmplite in the tests directory, and noticed that pep8 was being used to check the code.  I have been using flake8 in my python projects, which performs more extensive linting checks, such as unused imports.  It helped warn me about grep and netstat being unused in the ```lib/utils.py``` file, as a result of yesterday's merge using code from netifaces.

In order to help "sixify" the rtmp code (I am not having nearly as many problems with the screenly code), I decided to use ```autopep8``` to help clean it up a bit.  The ```rtmplite``` repo looks like it's been mostly abandoned.  The autopep8 tool has a few features that help to "futurize" the code for python3, and it seemed to be easier to use that, rather than manually digging into that mess.

I am not sure how y'all feel about the styling changes.  I tried to break the lines only when it seemed the best approach, and placed ```# noqa``` comments at the end of the long lines that I thought were probably better left alone.

One of the newer errors flagged by pycodestyle is bare except statements.  Changing those to ```except BaseException``` silences the checker, but doesn't really provide the proper fix.  I changed a few of the bare excepts to be excepting BaseException, but decided to start ignoring those as well.  ```E722``` was added to the ignore option in the ```.travis.yml``` file, however my preference is to not ignore these issues, but actually except the most common error that may occur, and fail on unexpected errors, dealing with those as they arise.  The bare excepts say, "it doesn't matter what goes wrong," which may not always be the case.  This could potentially provide a false positive that the code is working, when something is really broken.

I decided to futurize ```bin/migrate.py``` even though this branch isn't focused on "sixifying" the code, since that seems to be the only place in the screenly code that the print statement is being used.

I'm sorry about the size of this PR.  I integrated travis-ci in my fork to help test this as I was working on it.  The past few commits have been successful on travis, so I decided to go ahead and open this PR, then get back to sixifying the rest of the code.



