### PR TITLE
Is simple http server needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ script:
   - find . ! -path "*/rtmplite/*" -name \*.py -exec pep8 --ignore=E402,E501,E731 {} +
   - nosetests -v -a '!fixme' --with-isolation
   - ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
+  - python -m SimpleHTTPServer 8081 &
   - sleep 3
   - bash static/spec/runner.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ script:
   - find . ! -path "*/rtmplite/*" -name \*.py -exec pep8 --ignore=E402,E501,E731 {} +
   - nosetests -v -a '!fixme' --with-isolation
   - ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
-  #- python -m SimpleHTTPServer 8080 &
   - sleep 3
   - bash static/spec/runner.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - find . ! -path "*/rtmplite/*" -name \*.py -exec pep8 --ignore=E402,E501,E731 {} +
   - nosetests -v -a '!fixme' --with-isolation
   - ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
-  - python -m SimpleHTTPServer 8080 &
+  #- python -m SimpleHTTPServer 8080 &
   - sleep 3
   - bash static/spec/runner.sh
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To simplify development of the server module of Screenly OSE, we've created a Do
 Assuming you're in the source code repository, simply run:
 
 ```
-$ docker run --rm -ti \
+$ docker run --rm -it \
     --name=screenly-dev \
     -e 'LISTEN=0.0.0.0' \
     -p 8080:8080 \

--- a/static/spec/phantom-runner.js
+++ b/static/spec/phantom-runner.js
@@ -1,6 +1,6 @@
 var webPage = require('webpage');
 var page = webPage.create();
-var url = 'http://localhost:8080/static/spec/runner.html';
+var url = 'http://localhost:8081/static/spec/runner.html';
 
 page.onConsoleMessage = function(msg, lineNum, sourceId) {
   console.log(msg);


### PR DESCRIPTION
It looks like the spec runner is using server.py and working well.  I don't think that using the simpleHTTPserver is needed.  On the chance that it is actually needed, we can use :8081 in the ```.travis.yml``` and ```phantomjs-runner.js``` files.
