### PR TITLE
Fixes black_screen when boot the system

### DIFF
--- a/ansible/roles/screenly/files/plymouth-quit-wait.service
+++ b/ansible/roles/screenly/files/plymouth-quit-wait.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Hold until boot process finishes up
+After=rc-local.service plymouth-start.service systemd-user-sessions.service screenly-viewer.service
+
+[Service]
+ExecStart=-/bin/plymouth --wait
+Type=oneshot
+TimeoutSec=0

--- a/ansible/roles/screenly/files/plymouth-quit.service
+++ b/ansible/roles/screenly/files/plymouth-quit.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Terminate Plymouth Boot Screen
+After=rc-local.service plymouth-start.service systemd-user-sessions.service screenly-viewer.service
+
+[Service]
+ExecStart=-/bin/plymouth quit
+Type=oneshot
+TimeoutSec=20

--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -84,6 +84,22 @@
     dest: "/etc/systemd/system/{{ item }}"
   with_items: "{{ screenly_systemd_units }}"
 
+- name: Copy plymouth-quit-wait.service
+  copy:
+    src: plymouth-quit-wait.service
+    dest: /lib/systemd/system/plymouth-quit-wait.service
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Copy plymouth-quit.service
+  copy:
+    src: plymouth-quit.service
+    dest: /lib/systemd/system/plymouth-quit.service
+    mode: 0755
+    owner: root
+    group: root
+
 - name: Enable screenly systemd services
   command: systemctl enable {{ item }} chdir=/etc/systemd/system
   with_items: "{{ screenly_systemd_units }}"


### PR DESCRIPTION
This fixes for #836 issue.
We have black screen because the splashscreen stop before the launch of all services .
These changes stay plymouth service until the boot is fully loaded and the screenly-viewer is launched.