### PR TITLE
Some fixes for stuck when alert, confirm or prompt

### DIFF
--- a/ansible/roles/screenly/files/uzbl-config
+++ b/ansible/roles/screenly/files/uzbl-config
@@ -1,2 +1,6 @@
 set show_status = 0
-set ssl_verify = 1
+set ssl_verify  = 1
+set on_event    = request ON_EVENT
+
+@on_event   LOAD_START         js alert=function(e){return true};confirm=function(e){return true};prompt=function(e){return true};
+@on_event   LOAD_COMMIT        js alert=function(e){return true};confirm=function(e){return true};prompt=function(e){return true};

--- a/ansible/roles/screenly/files/uzbl-config
+++ b/ansible/roles/screenly/files/uzbl-config
@@ -1,5 +1,4 @@
 set show_status = 0
-set ssl_verify  = 1
 set on_event    = request ON_EVENT
 
 @on_event   LOAD_START         js alert=function(e){return true};confirm=function(e){return true};prompt=function(e){return true};

--- a/viewer.py
+++ b/viewer.py
@@ -250,13 +250,13 @@ def browser_send(command, cb=lambda _: True):
         browser.process.stdin.put(command + '\n')
         while True:  # loop until cb returns True
             try:
-                event = browser.next()
+                browser_event = browser.next()
             except StopIteration:
                 break
-            if 'FOCUS_LOST' in event:
+            if 'FOCUS_LOST' in str(browser_event):
                 browser_focus_lost = True
                 break
-            if cb(event):
+            if cb(browser_event):
                 break
     else:
         logging.info('browser found dead, restarting')


### PR DESCRIPTION
This fixes for #848 issue.
If screenly viewer has a web page asset with an alert, confirmation or promt, the viewer will stuck until we close the interactive box.
These fixes allow you to insert a js code that overwrite alerts, confirms and prompts in most cases, through the event in the config file uzbl. However, there is a little chance that this will not help, and then we catch the event when the browser focus has losted, and at the end of the asset's duration we close the page.