### PR TITLE
Add pause for screenly-viewer container in ansible-playbook

### DIFF
--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -124,6 +124,9 @@
       - /home/pi/.screenly:/home/pi/.screenly
       - /home/pi/screenly_assets:/home/pi/screenly_assets
 
+- name: Pause screenly-viewer container
+  command: docker pause screenly-ose-viewer
+
 - name: Create screenly-websocket-server container
   docker_container:
     name: screenly-ose-websocket


### PR DESCRIPTION
#### Overview of the Issue

When performing a task with creating a screely-ose-viewer container in during the work of the ansible-playbook(experimental branch). the container starts up immediately. It blocks the work of the ansible-playbook. (screenly-viewer running with splash page and also we can't use keyboard) 
These changes pause working of this container until the system is rebooted.
In official ansible documentation we can read about paused tag for docker_container, but this tag not worked there.
If changes state in task, It also does not give the desired result. Since it will be necessary to create services for running containers with system.

#### Reproduction Steps

Steps to reproduce this issue, eg:

* Run ansible-playbook in experimental branch
* Wait create screenly-viewer task

