### PR TITLE
Bug associated with determining the type of file for experimental

### DIFF
--- a/static/js/screenly-ose.coffee
+++ b/static/js/screenly-ose.coffee
@@ -183,7 +183,7 @@ API.View.AddAssetView = class AddAssetView extends Backbone.View
         maxChunkSize: 5000000 #5 MB
         url: 'api/v1/file_asset'
         progressall: (e, data) => if data.loaded and data.total
-          (@$ '.progress .bar').css 'width', "#{data.loaded/data.total*100}%"
+          (@$ '.progress .bar').css 'width', "#{data.loaded / data.total * 100}%"
         add: (e, data) ->
           (that.$ '.status').hide()
           (that.$ '.progress').show()
@@ -229,7 +229,7 @@ API.View.AddAssetView = class AddAssetView extends Backbone.View
   updateFileUploadMimetype: (filename) => @updateMimetype filename
   updateMimetype: (filename) =>
     mt = get_mimetype filename
-    @$fv 'mimetype', mt if mt
+    @$fv 'mimetype', if mt then mt else new Asset().defaults()['mimetype']
     @change_mimetype()
 
   change: (e) =>

--- a/static/js/screenly-ose.js
+++ b/static/js/screenly-ose.js
@@ -414,9 +414,7 @@
     AddAssetView.prototype.updateMimetype = function(filename) {
       var mt;
       mt = get_mimetype(filename);
-      if (mt) {
-        this.$fv('mimetype', mt);
-      }
+      this.$fv('mimetype', mt ? mt : new Asset().defaults()['mimetype']);
       return this.change_mimetype();
     };
 
@@ -1034,3 +1032,5 @@
   })(Backbone.View);
 
 }).call(this);
+
+//# sourceMappingURL=screenly-ose.js.map


### PR DESCRIPTION
I was able to reproduce this issue #841.
![error_1](https://user-images.githubusercontent.com/17593028/46717143-8d1e6c80-cc88-11e8-9db0-38ad42ada124.png)
The reason is the incorrect definition of the file mimetype in js code.
This edits allows to take the default value, if js could not determine the type of file.