### PR TITLE
Bug associated with determining the type of file

### DIFF
--- a/server.py
+++ b/server.py
@@ -817,8 +817,12 @@ class FileAsset(Resource):
         req = Request(request.environ)
         file_upload = req.files.get('file_upload')
         filename = file_upload.filename
+        file_type = guess_type(filename)[0]
 
-        if guess_type(filename)[0].split('/')[0] not in ['image', 'video']:
+        if not file_type:
+            raise Exception("Invalid file type.")
+
+        if file_type.split('/')[0] not in ['image', 'video']:
             raise Exception("Invalid file type.")
 
         file_path = path.join(settings['assetdir'], filename) + ".tmp"

--- a/static/js/screenly-ose.coffee
+++ b/static/js/screenly-ose.coffee
@@ -229,7 +229,7 @@ API.View.AddAssetView = class AddAssetView extends Backbone.View
   updateFileUploadMimetype: (filename) => @updateMimetype filename
   updateMimetype: (filename) =>
     mt = get_mimetype filename
-    @$fv 'mimetype', mt if mt
+    @$fv 'mimetype', if mt then mt else new Asset().defaults()['mimetype']
     @change_mimetype()
 
   change: (e) =>

--- a/static/js/screenly-ose.js
+++ b/static/js/screenly-ose.js
@@ -414,9 +414,7 @@
     AddAssetView.prototype.updateMimetype = function(filename) {
       var mt;
       mt = get_mimetype(filename);
-      if (mt) {
-        this.$fv('mimetype', mt);
-      }
+      this.$fv('mimetype', mt ? mt : new Asset().defaults()['mimetype']);
       return this.change_mimetype();
     };
 


### PR DESCRIPTION
I was able to reproduce this issue #841.
![error_1](https://user-images.githubusercontent.com/17593028/46717331-509f4080-cc89-11e8-86bb-5b8b83f8059d.png)
The reason is the incorrect definition of the file mimetype in js code.
This edits allows to take the default value, if js could not determine the type of file.
Also i have this error when upload file without file extension.
![error_3](https://user-images.githubusercontent.com/17593028/46717395-965c0900-cc89-11e8-85f2-038d71bc292d.png)
For this situation i made edits in server python file.
