### PR TITLE
Fixes for splashscreen

### DIFF
--- a/ansible/roles/splashscreen/files/plymouthd.default
+++ b/ansible/roles/splashscreen/files/plymouthd.default
@@ -1,0 +1,5 @@
+# Distribution defaults. Changes to this file will get overwritten during
+# upgrades.
+[Daemon]
+Theme=screenly
+ShowDelay=0

--- a/ansible/roles/splashscreen/tasks/main.yml
+++ b/ansible/roles/splashscreen/tasks/main.yml
@@ -47,6 +47,7 @@
     name: "{{ item }}"
   with_items:
     - plymouth
+    - pix-plym-splash
   when: ansible_distribution_major_version|int > 7
 
 - name: Copies plymouth theme
@@ -61,4 +62,10 @@
 
 - name: Set splashscreen
   command: plymouth-set-default-theme -R screenly
+  when: ansible_distribution_major_version|int > 7
+
+- name: Set plymouthd.default
+  copy:
+    src: plymouthd.default
+    dest: /usr/share/plymouth/plymouthd.default
   when: ansible_distribution_major_version|int > 7


### PR DESCRIPTION
#922
When I was solving the issue described here #836, I was faced with the fact that on some versions of Raspberry Pi( In my case, Raspberry Pi 1 and sometimes with Raspberry Pi Zero W) there haven't Screenly splashscreen. Instead, I had a splashscreen with 3 dots is displayed.
These edits fix this problem.
