### PR TITLE
Remove url_for from hotspot.html

### DIFF
--- a/templates/hotspot.html
+++ b/templates/hotspot.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8"/>
     <title>Hotspot Page</title>
-    <link href="{{ url_for('static', filename='css/bootstrap.min.css') }}" rel="stylesheet"/>
-    <link href="{{ url_for('static', filename='css/screenly.css') }}" rel="stylesheet"/>
+    <link href="/static/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="/static/css/screenly.css" rel="stylesheet"/>
 </head>
 <body class="splash">
 <div class="container">


### PR DESCRIPTION
Undefined url_for in hotspot, when starting script start_resin_wifi.