### PR TITLE
Ability to use the keyboard as needed

### DIFF
--- a/ansible/roles/screenly/files/uzbl-config-keyboard-enable
+++ b/ansible/roles/screenly/files/uzbl-config-keyboard-enable
@@ -1,0 +1,65 @@
+set show_status = 0
+
+# === Core settings ==========================================================
+
+# common directory locations
+set prefix      = @(echo $PREFIX)@
+set data_home   = @(echo $XDG_DATA_HOME)@
+set cache_home  = @(echo $XDG_CACHE_HOME)@
+set config_home = @(echo $XDG_CONFIG_HOME)@
+
+# Interface paths.
+set fifo_dir   = /tmp
+set socket_dir = /tmp
+
+set shell_cmd       = sh -c
+
+# === General config aliases =================================================
+
+# Config related events (use the request function):
+# request MODE_CONFIG <mode> <key> = <value>
+set mode_config     = request MODE_CONFIG
+# request ON_EVENT <EVENT_NAME> <command>
+set on_event        = request ON_EVENT
+
+set set_mode        = set mode =
+set set_status      = set status_message =
+
+# Spawn path shortcuts. In spawn the first dir+path match is used in "dir1:dir2:dir3:executable"
+set scripts_dir      = @data_home/uzbl:@prefix/share/uzbl/examples/data:scripts
+
+# === Dynamic event handlers =================================================
+
+# Switch to insert mode if a (editable) html form is clicked
+@on_event   FOCUS_ELEMENT  sh 'if [ "$1" = INPUT -o "$1" = TEXTAREA -o "$1" = SELECT ]; then echo "@set_mode insert" > $UZBL_FIFO; fi' %s
+
+
+# === Mode configuration =====================================================
+
+# Define some mode specific uzbl configurations.
+set command  = @mode_config command
+set insert   = @mode_config insert
+set stack    = @mode_config stack
+
+# Command mode config.
+@command  keycmd_events       = 1
+@command  forward_keys        = 0
+@command  modcmd_updates      = 1
+
+# Insert mode config.
+@insert   forward_keys        = 1
+@insert   keycmd_events       = 0
+@insert   modcmd_updates      = 0
+
+# Multi-stage-binding mode config.
+@stack    keycmd_events       = 1
+@stack    modcmd_updates      = 1
+@stack    forward_keys        = 0
+
+set default_mode = command
+
+
+# === SCRIPTS =================================================================
+
+@on_event   LOAD_START         js alert=function(e){return true};confirm=function(e){return true};prompt=function(e){return true};
+@on_event   LOAD_COMMIT        js alert=function(e){return true};confirm=function(e){return true};prompt=function(e){return true};

--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -37,6 +37,13 @@
     src: uzbl-config
     dest: /home/pi/.config/uzbl/config-screenly
 
+- name: Copy in UZBL config keyboard enable
+  copy:
+    owner: pi
+    group: pi
+    src: uzbl-config-keyboard-enable
+    dest: /home/pi/.config/uzbl/config-screenly-keyboard-enable
+
 - name: Install pip dependencies
   pip: requirements=/home/pi/screenly/requirements.txt
 

--- a/settings.py
+++ b/settings.py
@@ -32,7 +32,8 @@ DEFAULTS = {
         'default_duration': '10',
         'default_streaming_duration': '300',
         'debug_logging': False,
-        'verify_ssl': True
+        'verify_ssl': True,
+        'use_keyboard': False
     },
     'auth': {
         'user': '',

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -193,6 +193,24 @@
                 </div>
 
                 <div class="form-group row">
+                    <label class="col-2 col-form-label">Use keyboard</label>
+                    <div class="col-3">
+                        <label id="use_keyboard_checkbox" class="checkbox toggle card card-body bg-light">
+                            {% if context.use_keyboard %}
+                                <input name="use_keyboard" checked="checked" type="checkbox">
+                            {% else %}
+                                <input name="use_keyboard" type="checkbox">
+                            {% endif %}
+                            <p>
+                                <span class="on">On</span>
+                                <span class="off">Off</span>
+                            </p>
+                            <a class="btn btn-primary slide-button"></a>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="form-group row">
                     <label class="col-2 col-form-label">Use Authentication</label>
                     <div class="col-3">
                         <label id="auth_checkbox" class="checkbox toggle card card-body bg-light">


### PR DESCRIPTION
Currently, Screenly-OSE does not have the ability to interact with the page using the keyboard. As we can see in this question #721, it creates some inconvenience for users.
This commit allows you to enable the use of the keyboard via the settings page.
When switching this parameter, the script analyzes which config currently uses the uzbl-browser and when you change "Use keyboard" restarts the browser with the desired config.
![keyboard_support](https://user-images.githubusercontent.com/17593028/47898591-bc4b8680-dea0-11e8-82ce-dd2bbc4924bb.png)
@vpetersson What do you think about it?