### PR TITLE
Updated version of screenly-webview to v0.2

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -63,9 +63,9 @@ RUN ln -s /opt/vc/lib/libbrcmGLESv2.so /usr/lib/arm-linux-gnueabihf/libGLESv2.so
 
 RUN mkdir /usr/local/share/ScreenlyWebview
 RUN curl -L  \
-    "https://github.com/Screenly/screenly-ose-webview/releases/download/v0.1/screenly-webview-v0.1.tar.gz" \
-    > /tmp/screenly-webview-v0.1.tar.gz
-RUN tar -xzf /tmp/screenly-webview-v0.1.tar.gz -C /tmp
+    "https://github.com/Screenly/screenly-ose-webview/releases/download/v0.2/screenly-webview-v0.2.tar.gz" \
+    > /tmp/screenly-webview-v0.2.tar.gz
+RUN tar -xzf /tmp/screenly-webview-v0.2.tar.gz -C /tmp
 
 RUN cp -r /tmp/res /usr/local/share/ScreenlyWebview/res
 RUN cp /tmp/ScreenlyWebview /usr/local/bin/ScreenlyWebview

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -63,9 +63,9 @@ RUN ln -s /opt/vc/lib/libbrcmGLESv2.so /usr/lib/arm-linux-gnueabihf/libGLESv2.so
 
 RUN mkdir /usr/local/share/ScreenlyWebview
 RUN curl -L  \
-    "https://github.com/Screenly/screenly-ose-webview/releases/download/v0.2/screenly-webview-v0.2.tar.gz" \
-    > /tmp/screenly-webview-v0.2.tar.gz
-RUN tar -xzf /tmp/screenly-webview-v0.2.tar.gz -C /tmp
+    "https://github.com/Screenly/screenly-ose-webview/releases/download/0.2/screenly-webview-0.2.tar.gz" \
+    > /tmp/screenly-webview-0.2.tar.gz
+RUN tar -xzf /tmp/screenly-webview-0.2.tar.gz -C /tmp
 
 RUN cp -r /tmp/res /usr/local/share/ScreenlyWebview/res
 RUN cp /tmp/ScreenlyWebview /usr/local/bin/ScreenlyWebview

--- a/Dockerfile.viewer
+++ b/Dockerfile.viewer
@@ -57,9 +57,9 @@ ENV QT_QPA_PLATFORM eglfs
 
 RUN mkdir /usr/local/share/ScreenlyWebview
 RUN curl -L  \
-    "https://github.com/Screenly/screenly-ose-webview/releases/download/v0.2/screenly-webview-v0.2.tar.gz" \
-    > /tmp/screenly-webview-v0.2.tar.gz
-RUN tar -xzf /tmp/screenly-webview-v0.2.tar.gz -C /tmp
+    "https://github.com/Screenly/screenly-ose-webview/releases/download/0.2/screenly-webview-0.2.tar.gz" \
+    > /tmp/screenly-webview-0.2.tar.gz
+RUN tar -xzf /tmp/screenly-webview-0.2.tar.gz -C /tmp
 
 RUN cp -r /tmp/res /usr/local/share/ScreenlyWebview/res
 RUN cp /tmp/ScreenlyWebview /usr/local/bin/ScreenlyWebview

--- a/Dockerfile.viewer
+++ b/Dockerfile.viewer
@@ -57,9 +57,9 @@ ENV QT_QPA_PLATFORM eglfs
 
 RUN mkdir /usr/local/share/ScreenlyWebview
 RUN curl -L  \
-    "https://github.com/Screenly/screenly-ose-webview/releases/download/v0.1/screenly-webview-v0.1.tar.gz" \
-    > /tmp/screenly-webview-v0.1.tar.gz
-RUN tar -xzf /tmp/screenly-webview-v0.1.tar.gz -C /tmp
+    "https://github.com/Screenly/screenly-ose-webview/releases/download/v0.2/screenly-webview-v0.2.tar.gz" \
+    > /tmp/screenly-webview-v0.2.tar.gz
+RUN tar -xzf /tmp/screenly-webview-v0.2.tar.gz -C /tmp
 
 RUN cp -r /tmp/res /usr/local/share/ScreenlyWebview/res
 RUN cp /tmp/ScreenlyWebview /usr/local/bin/ScreenlyWebview


### PR DESCRIPTION
#806
Updated version of screenly-webview from 0.1 to v0.2
https://github.com/Screenly/screenly-ose-webview/releases/tag/0.2