### PR TITLE
No longer stops viewer if page load failed

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -412,7 +412,9 @@ def asset_loop(scheduler):
         elif 'web' in mime:
             # FIXME If we want to force periodic reloads of repeated web assets, force=True could be used here.
             # See e38e6fef3a70906e7f8739294ffd523af6ce66be.
-            browser_url(uri, cb=lambda b: 'LOAD_FINISH' in unicode(b.decode('utf-8')))
+            browser_url(uri,
+                        cb=lambda b: 'LOAD_FINISH' in unicode(b.decode('utf-8')) or
+                                     'LOAD_ERROR' in unicode(b.decode('utf-8')))
         elif 'video' or 'streaming' in mime:
             view_video(uri, asset['duration'])
         else:


### PR DESCRIPTION
Refs: #974 #966
These edits resolved problem when page load was fail.
