### PR TITLE
Set large timeout for backup

### DIFF
--- a/ansible/roles/nginx/files/nginx.conf
+++ b/ansible/roles/nginx/files/nginx.conf
@@ -24,6 +24,19 @@ server {
     proxy_set_header Host $http_host;
   }
 
+  location ~ ^/api/[0-9a-z]+/backup$ {
+    proxy_pass http://ose;
+    proxy_connect_timeout 1800;
+    proxy_send_timeout 1800;
+    proxy_read_timeout 1800;
+    send_timeout 1800;
+
+    client_max_body_size 4G;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+  }
+
   location /static {
     proxy_pass http://ose/static;
   }

--- a/static/js/settings.coffee
+++ b/static/js/settings.coffee
@@ -10,7 +10,12 @@ $().ready ->
     $('#btn-upload').prop 'disabled', yes
     $('#btn-backup').prop 'disabled', yes
 
-    $.post "api/v1/backup"
+    $.ajax({
+      method: "POST"
+      url: "api/v1/backup"
+      timeout: 1800 * 1000
+    })
+
     .done  (data, e) ->
       if (data)
         window.location = "static_with_mime/" + data + "?mime=application/x-tgz"

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -10,7 +10,11 @@
       $('#btn-backup').text("Preparing archive...");
       $('#btn-upload').prop('disabled', true);
       $('#btn-backup').prop('disabled', true);
-      return $.post("api/v1/backup").done(function(data, e) {
+      return $.ajax({
+        method: "POST",
+        url: "api/v1/backup",
+        timeout: 1800 * 1000
+      }).done(function(data, e) {
         if (data) {
           return window.location = "static_with_mime/" + data + "?mime=application/x-tgz";
         }
@@ -102,3 +106,5 @@
   });
 
 }).call(this);
+
+//# sourceMappingURL=settings.js.map


### PR DESCRIPTION
Discussion of the issue #977

These edits make fix when it was not possible to download a backup if .tar is generated more than 30 seconds.
Now the timeout is 30 minutes.