### PR TITLE
SIGALRM when viewer stuck

### DIFF
--- a/lib/errors.py
+++ b/lib/errors.py
@@ -1,0 +1,2 @@
+class SigalrmException(Exception):
+    pass


### PR DESCRIPTION
Thanks to this issue #995, I found next problem
Reproduce steps:
- Activate asset with this url https://www.instagram.com/epsbn9/?hl=en
- Disable asset above
- Try activate asset above one more time.
- Then we'll see that we're stuck on black_page.html

These edits have:
Send a signal SIGALRM in 10 seconds when we started to receive data from the browser process. If the browser process does not receive any data during this time, an exception will be thrown out and the viewer will continue to work.