### PR TITLE
Only one active upgrade_screenly task

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -16,4 +16,4 @@ RUN chown -R pi:pi /home/pi
 USER pi
 WORKDIR /home/pi/screenly
 
-CMD celery worker -A server.celery --loglevel=info
+CMD celery worker -A server.celery -B -n worker@screenly --loglevel=info

--- a/ansible/roles/screenly/files/screenly-celery.service
+++ b/ansible/roles/screenly/files/screenly-celery.service
@@ -5,7 +5,7 @@ After=redis-server.service
 [Service]
 WorkingDirectory=/home/pi/screenly
 User=pi
-ExecStart=/usr/local/bin/celery worker -A server.celery -B --loglevel=info
+ExecStart=/usr/local/bin/celery worker -A server.celery -B -n worker@screenly --loglevel=info
 Restart=always
 RestartSec=5
 

--- a/server.py
+++ b/server.py
@@ -1037,6 +1037,9 @@ class UpgradeScreenly(Resource):
         }
     })
     def post(self):
+        for task in celery.control.inspect().active().get('worker@screenly'):
+            if task.get('type') == 'server.upgrade_screenly':
+                return jsonify({'id': task.get('id')})
         branch = request.form.get('branch')
         manage_network = request.form.get('manage_network')
         system_upgrade = request.form.get('system_upgrade')


### PR DESCRIPTION
These edits do not allow to run more than one screenly_upgrade task from the web interface.