### PR TITLE
Add installer for libraspberrypi0 and ifupdown, also chmod vchiq

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -72,4 +72,5 @@ RUN chown -R pi:pi /home/pi
 
 WORKDIR /home/pi/screenly
 
+CMD ["bash", "chmod 777 /dev/vchiq"]
 CMD ["bash", "bin/start_resin.sh"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -17,6 +17,8 @@ RUN apt-get update && \
         python-imaging \
         python-netifaces \
         python-simplejson \
+        libraspberrypi0 \
+        ifupdown \
         sqlite3 \
         uzbl \
         x11-xserver-utils \


### PR DESCRIPTION
These steps were necessary in order to get screenly to function correctly when installing it on Balena Cloud. I've decided to PR these changes in an attempt to share my fixes with everyone else that uses screenly.