### PR TITLE
Allow PLAYER_NAME environment variable

### DIFF
--- a/bin/start_resin.sh
+++ b/bin/start_resin.sh
@@ -26,6 +26,12 @@ if [ -n "${MANAGEMENT_USER+x}" ] && [ -n "${MANAGEMENT_PASSWORD+x}" ]; then
     sed -i -e "s/^user=.*/user=${MANAGEMENT_USER}/" -e "s/^password=.*/password=${MANAGEMENT_PASSWORD}/" /data/.screenly/screenly.conf
 fi
 
+if [ -n "${PLAYER_NAME+x}" ]; then
+    sed -i -e "s/^player_name=.*/player_name=${PLAYER_NAME}/" /data/.screenly/screenly.conf
+else
+    sed -i -e "s/^player_name=.*/player_name=${BALENA_DEVICE_NAME_AT_INIT}/" /data/.screenly/screenly.conf
+fi
+
 sed -i "/\[Service\]/ a\Environment=RESIN_UUID=${RESIN_DEVICE_UUID}" /etc/systemd/system/screenly-web.service
 
 systemctl start X.service


### PR DESCRIPTION
This pull request has two proposed changes for balenaCloud devices:
1. Allows the environment variable ```PLAYER_NAME``` to be set in the balenaCloud administration panel.
2. If ```PLAYER_NAME``` is not set in the balenaCloud administration panel, the player name will default to ```BALENA_DEVICE_NAME_AT_INIT```, or the device's name when it is first initialized on balenaCloud.