### PR TITLE
Fix: UUID name for *.tmp asset when upload

### DIFF
--- a/server.py
+++ b/server.py
@@ -866,7 +866,7 @@ class FileAsset(Resource):
         if file_type.split('/')[0] not in ['image', 'video']:
             raise Exception("Invalid file type.")
 
-        file_path = path.join(settings['assetdir'], filename) + ".tmp"
+        file_path = path.join(settings['assetdir'], uuid.uuid4().hex) + ".tmp"
 
         if 'Content-Range' in request.headers:
             range_str = request.headers['Content-Range']

--- a/server.py
+++ b/server.py
@@ -866,7 +866,7 @@ class FileAsset(Resource):
         if file_type.split('/')[0] not in ['image', 'video']:
             raise Exception("Invalid file type.")
 
-        file_path = path.join(settings['assetdir'], uuid.uuid4().hex) + ".tmp"
+        file_path = path.join(settings['assetdir'], uuid.uuid5(uuid.NAMESPACE_URL, filename.encode()).hex) + ".tmp"
 
         if 'Content-Range' in request.headers:
             range_str = request.headers['Content-Range']


### PR DESCRIPTION
Ref #1024
*IN:*
```
curl \
	-H "Content-Type: multipart/form-data"  \
	-X POST \
	-F "file_upload=@test.jpg" \
	http://x.x.x.x/api/v1/file_asset
```
*OUT:*
```
"/home/pi/screenly_assets/77586f3c25094119a721d5d2db48b8cc.tmp"
```

*IN:*
```
curl \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{"duration": "10", "end_date": "2019-03-31T06:39:00.000Z", "is_active": 1, "is_enabled": 0, "is_processing": 0, "mimetype": "image", "name": "test.jpg", "nocache": 0, "play_order": 0, "skip_asset_check": "0", "start_date": "2019-03-01T06:39:00.000Z", "uri": "77586f3c25094119a721d5d2db48b8cc.tmp" }' \
    http://x.x.x.x/api/v1.2/assets
```
*OUT:*
```
{"asset_id": "8754f372ac3241bd8b174d6ce37c490a", "mimetype": "image", "name": "test.jpg", "end_date": "2019-03-31T06:39:00+00:00", "is_enabled": 0, "nocache": 0, "is_active": 0, "uri": "/home/pi/screenly_assets/8754f372ac3241bd8b174d6ce37c490a", "skip_asset_check": 0, "duration": "10", "play_order": 0, "start_date": "2019-03-01T06:39:00+00:00", "is_processing": 0}
```
