### PR TITLE
Fix: Docker containers timezone are now synchronized with the host

### DIFF
--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -108,6 +108,8 @@
       - /home/pi/screenly:/home/pi/screenly
       - /home/pi/.screenly:/home/pi/.screenly
       - /home/pi/screenly_assets:/home/pi/screenly_assets
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
 
 - name: Create screenly-viewer container
   docker_container:
@@ -123,6 +125,8 @@
       - /home/pi/screenly:/home/pi/screenly
       - /home/pi/.screenly:/home/pi/.screenly
       - /home/pi/screenly_assets:/home/pi/screenly_assets
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
 
 - name: Create screenly-websocket-server container
   docker_container:
@@ -136,3 +140,5 @@
     volumes:
       - /home/pi/screenly:/home/pi/screenly
       - /home/pi/.screenly:/home/pi/.screenly
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
Discussion #1038 

Before
```
pi@raspberrypi:~ $ date
Fri Mar 22 02:26:31 -06 2019
pi@raspberrypi:~ $ docker exec screenly-ose-viewer date
Fri Mar 22 08:26:38 UTC 2019
```

Now
```
pi@raspberrypi:~ $ date 
Fri Mar 22 02:27:32 -06 2019
pi@raspberrypi:~ $ docker exec screenly-ose-viewer date   
Fri Mar 22 02:27:35 -06 2019
```