### PR TITLE
Update Dockerfile.template to use balenalib base images

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-debian
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:jessie
 MAINTAINER Anton Molodykh <amolodykh@screenly.io>
 
 RUN apt-get update && \


### PR DESCRIPTION
The `latest` in `resin` was jessie, but in `balenalib` it's `stretch` so we need to specify `jessie` explicitly.