### PR TITLE
Update utils.py

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -23,7 +23,8 @@ from assets_helper import update
 
 arch = machine()
 
-HTTP_OK = xrange(200, 299)
+# 300 level HTTP responses are also ok, such as redirects, which many sites have and load
+HTTP_OK = xrange(200, 399)
 
 # This will only work on the Raspberry Pi,
 # so let's wrap it in a try/except so that
@@ -151,11 +152,11 @@ def url_fails(url):
     Try HEAD and GET for URL availability check.
     """
 
-    # Use Certifi module
+    # Use Certifi module and set to True as default so users stop seeing InsecureRequestWarning in logs
     if settings['verify_ssl']:
         verify = certifi.where()
     else:
-        verify = False
+        verify = True
 
     headers = {
         'User-Agent': 'Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/538.15 (KHTML, like Gecko) Version/8.0 Safari/538.15'


### PR DESCRIPTION
Change in HTTP xrange since redirect responses are also OK.
Set request verification to true to stop urllib InsecureRequestWarning showing up in logs and users mistakenly thinking this is what causes the TLS handshake error..