### PR TITLE
New endpoint: viewer's currenlty asset

### DIFF
--- a/lib/errors.py
+++ b/lib/errors.py
@@ -1,2 +1,6 @@
 class SigalrmException(Exception):
     pass
+
+
+class ZmqCollectorTimeout(Exception):
+    pass

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+import json
 from os import path, getenv
 from sys import exit
 from time import sleep
@@ -11,6 +11,8 @@ from flask import request, Response
 from functools import wraps
 import zmq
 import hashlib
+
+from lib.errors import ZmqCollectorTimeout
 
 CONFIG_DIR = '.screenly/'
 CONFIG_FILE = 'screenly.conf'
@@ -164,6 +166,50 @@ class ZmqPublisher:
 
     def send_to_viewer(self, msg):
         self.socket.send_string("viewer {}".format(msg))
+
+
+class ZmqConsumer:
+    def __init__(self):
+        self.context = zmq.Context()
+
+        self.socket = self.context.socket(zmq.PUSH)
+        self.socket.setsockopt(zmq.LINGER, 0)
+        self.socket.connect('tcp://127.0.0.1:5558')
+
+        sleep(1)
+
+    def send(self, msg):
+        self.socket.send_json(msg, flags=zmq.NOBLOCK)
+
+
+class ZmqCollector:
+    INSTANCE = None
+
+    def __init__(self):
+        if self.INSTANCE is not None:
+            raise ValueError("An instantiation already exists!")
+
+        self.context = zmq.Context()
+
+        self.socket = self.context.socket(zmq.PULL)
+        self.socket.bind('tcp://127.0.0.1:5558')
+
+        self.poller = zmq.Poller()
+        self.poller.register(self.socket, zmq.POLLIN)
+
+        sleep(1)
+
+    @classmethod
+    def get_instance(cls):
+        if cls.INSTANCE is None:
+            cls.INSTANCE = ZmqCollector()
+        return cls.INSTANCE
+
+    def recv_json(self, timeout):
+        if self.poller.poll(timeout):
+            return json.loads(self.socket.recv(zmq.NOBLOCK))
+
+        raise ZmqCollectorTimeout
 
 
 def authenticate():

--- a/viewer.py
+++ b/viewer.py
@@ -92,11 +92,9 @@ def command_not_found():
 
 def send_current_asset_id_to_server():
     current_asset_id = None
-
-    try:
-        current_asset_id = scheduler.assets[scheduler.index].get('asset_id')
-    except IndexError:
-        pass
+    if scheduler.assets:
+        index = (scheduler.index - 1) % len(scheduler.assets)
+        current_asset_id = scheduler.assets[index].get('asset_id')
 
     consumer = ZmqConsumer()
     consumer.send({'current_asset_id': current_asset_id})

--- a/viewer.py
+++ b/viewer.py
@@ -19,7 +19,7 @@ import string
 import zmq
 
 from lib.errors import SigalrmException
-from settings import settings, LISTEN, PORT
+from settings import settings, LISTEN, PORT, ZmqConsumer
 import html_templates
 from lib.github import fetch_remote_hash, remote_branch_available
 from lib.utils import url_fails, touch, is_ci
@@ -90,12 +90,25 @@ def command_not_found():
     logging.error("Command not found")
 
 
+def send_current_asset_id_to_server():
+    current_asset_id = None
+
+    try:
+        current_asset_id = scheduler.assets[scheduler.index].get('asset_id')
+    except IndexError:
+        pass
+
+    consumer = ZmqConsumer()
+    consumer.send({'current_asset_id': current_asset_id})
+
+
 commands = {
     'next': lambda _: skip_asset(),
     'previous': lambda _: skip_asset(back=True),
     'asset': lambda id: navigate_to_asset(id),
     'reload': lambda _: load_settings(),
-    'unknown': lambda _: command_not_found()
+    'unknown': lambda _: command_not_found(),
+    'current_asset_id': lambda _: send_current_asset_id_to_server()
 }
 
 


### PR DESCRIPTION
Feature request: #916

**In:**
```
pi@raspberrypi:~ $ curl http://127.0.0.1:8080/api/v1/viewer_current_asset
```

**Out:**
`
{"asset_id": "e6d61798365d4b3f88c64faa6ade8bc0", "mimetype": "webpage", "name": "Screenly Weather Widget", "end_date": "2024-11-23T21:21:34+00:00", "is_enabled": 1, "nocache": "", "is_active": 1, "uri": "https://weather.srly.io", "skip_asset_check": 0, "duration": "10", "play_order": 0, "start_date": "2018-11-23T21:21:34+00:00", "is_processing": 0}
`