### PR TITLE
Feature: MAC address on System Info

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -10,7 +10,7 @@ import string
 
 from datetime import datetime, timedelta
 from distutils.util import strtobool
-from netifaces import ifaddresses, gateways, AF_INET
+from netifaces import ifaddresses, gateways, AF_INET, AF_LINK
 from os import getenv, path, utime
 from platform import machine
 from settings import settings, ZmqPublisher
@@ -77,15 +77,27 @@ def validate_url(string):
 
 
 def get_node_ip():
-        """Returns the node's IP, for the interface
-        that is being used as the default gateway.
-        This should work on both MacOS X and Linux."""
-        try:
-            default_interface = gateways()['default'][AF_INET][1]
-            my_ip = ifaddresses(default_interface)[AF_INET][0]['addr']
-            return my_ip
-        except ValueError:
-            raise Exception("Unable to resolve local IP address.")
+    """Returns the node's IP, for the interface
+    that is being used as the default gateway.
+    This should work on both MacOS X and Linux."""
+    try:
+        default_interface = gateways()['default'][AF_INET][1]
+        my_ip = ifaddresses(default_interface)[AF_INET][0]['addr']
+        return my_ip
+    except (KeyError, ValueError):
+        raise Exception("Unable to resolve local IP address.")
+
+
+def get_node_mac_address():
+    """Returns the node's MAC address, for the interface
+    that is being used as the default gateway.
+    This should work on both MacOS X and Linux."""
+    try:
+        default_interface = gateways()['default'][AF_INET][1]
+        mac_address = ifaddresses(default_interface)[AF_LINK][0]['addr']
+        return mac_address
+    except (KeyError, ValueError):
+        pass
 
 
 def get_video_duration(file):

--- a/server.py
+++ b/server.py
@@ -33,7 +33,7 @@ from lib import db
 from lib import diagnostics
 from lib import queries
 
-from lib.utils import get_node_ip
+from lib.utils import get_node_ip, get_node_mac_address
 from lib.utils import get_video_duration
 from lib.utils import download_video_from_youtube, json_dump
 from lib.utils import url_fails
@@ -1328,7 +1328,8 @@ def system_info():
         display_info=display_info,
         display_power=display_power,
         raspberry_model=raspberry_model,
-        screenly_version=screenly_version
+        screenly_version=screenly_version,
+        mac_address=get_node_mac_address()
     )
 
 

--- a/templates/system_info.html
+++ b/templates/system_info.html
@@ -85,6 +85,7 @@
                     <th>Display Power</th>
                     <th>Raspberry Model</th>
                     <th>Screenly Version</th>
+                    <th>MAC address</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -96,6 +97,7 @@
                     <td>{{ context.display_power }}</td>
                     <td>{{ context.raspberry_model }}</td>
                     <td>{{ context.screenly_version }}</td>
+                    <td>{{ context.mac_address }}</td>
                 </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
Refs: #1049 #971

This PR adds Mac address information to the system info page.

![system_mac](https://user-images.githubusercontent.com/17593028/56657427-ce70e980-66b9-11e9-9f3c-46675ef70716.png)
