### PR TITLE
Fix: wifi-connect and wifi reset

### DIFF
--- a/ansible/roles/network/files/wifi-connect.service
+++ b/ansible/roles/network/files/wifi-connect.service
@@ -2,13 +2,13 @@
 Description=Wifi Connect
 Wants=network-online.target
 After=network-online.target
-ConditionPathExists=!/home/pi/.screenly/initialized
 
 [Service]
 WorkingDirectory=/home/pi/screenly
 User=pi
 Type=oneshot
 
+ExecStartPre=/bin/rm -f /home/pi/.screenly/initialized
 ExecStart=/usr/bin/python /home/pi/screenly/start_resin_wifi.py
 ExecStartPost=/usr/bin/touch /home/pi/.screenly/initialized
 

--- a/server.py
+++ b/server.py
@@ -33,6 +33,7 @@ from lib import db
 from lib import diagnostics
 from lib import queries
 
+from lib.utils import nmcli_get_connections, nmcli_remove_connection
 from lib.utils import get_node_ip, get_node_mac_address
 from lib.utils import get_video_duration
 from lib.utils import download_video_from_youtube, json_dump
@@ -973,6 +974,22 @@ class ResetWifiConfig(Resource):
 
         if path.isfile(file_path):
             remove(file_path)
+
+        device_uuid = None
+
+        wireless_connections = nmcli_get_connections(
+            'wlan*',
+            'ScreenlyOSE-*',
+            fields=['name', 'device', 'uuid'],
+            active=True
+        )
+        if wireless_connections:
+            _, _, device_uuid = wireless_connections[0].split(':')
+
+        if not device_uuid:
+            raise Exception('The device has no active connection.')
+
+        nmcli_remove_connection(device_uuid)
 
         return '', 204
 

--- a/start_resin_wifi.py
+++ b/start_resin_wifi.py
@@ -6,7 +6,7 @@ from os import getenv, path
 import re
 import sh
 
-from lib.utils import generate_perfect_paper_password
+from lib.utils import generate_perfect_paper_password, nmcli_get_connections
 
 
 def generate_page(ssid, pswd, address):
@@ -28,7 +28,9 @@ def generate_page(ssid, pswd, address):
 if __name__ == "__main__":
     r = re.compile("wlan*")
 
-    if not gateways().get('default') and filter(r.match, interfaces()):
+    wireless_connections = nmcli_get_connections('wlan*', 'ScreenlyOSE-*', active=True)
+
+    if not wireless_connections and not gateways().get('default') and filter(r.match, interfaces()):
         ssid = 'ScreenlyOSE-{}'.format(generate_perfect_paper_password(pw_length=4, has_symbols=False))
         ssid_password = generate_perfect_paper_password(pw_length=8, has_symbols=False)
         generate_page(ssid, ssid_password, 'screenly.io/wifi')

--- a/static/js/settings.coffee
+++ b/static/js/settings.coffee
@@ -77,6 +77,8 @@ $().ready ->
       $('#request-error .alert').addClass 'alert-success'
       $('#request-error .alert').removeClass 'alert-danger'
       ($ '#request-error .msg').text 'Reset was successful. Please reboot the device.'
+    .error (e) ->
+        document.location.reload()
 
   $('#auth_checkbox p span').click (e) ->
     if $('input:checkbox[name="use_auth"]').is(':checked')

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -86,6 +86,8 @@
         $('#request-error .alert').addClass('alert-success');
         $('#request-error .alert').removeClass('alert-danger');
         return ($('#request-error .msg')).text('Reset was successful. Please reboot the device.');
+      }).error(function(e) {
+        return document.location.reload();
       });
     });
     $('#auth_checkbox p span').click(function(e) {


### PR DESCRIPTION
We have issues about that people can not reset the current point of wifi or when user change the location of the device it does not show a point(balena) to connect to a new access wireless point.
This PR solve these problems.

General tests were reproduced:
- Connected to the point, after IP was displayed. Then, the current connection was reset through `http://ip/settings`. After reboot we can see the hotspot page.
- Successfully connected to the wireless point. Turn off the Wi-Fi router. After reboot we can see the hotspot page.