### PR TITLE
Update uzbl-config

### DIFF
--- a/ansible/roles/screenly/files/uzbl-config
+++ b/ansible/roles/screenly/files/uzbl-config
@@ -1,5 +1,6 @@
 set show_status = 0
-set on_event    = request ON_EVENT
+set on_event = request ON_EVENT
 
-@on_event   LOAD_START         js alert=function(e){return true};confirm=function(e){return true};prompt=function(e){return true};
-@on_event   LOAD_COMMIT        js alert=function(e){return true};confirm=function(e){return true};prompt=function(e){return true};
+@on_event   LOAD_START    js alert=function(e){return true};confirm=function(e){return true};prompt=function(e){return true};
+@on_event   LOAD_COMMIT   js alert=function(e){return true};confirm=function(e){return true};prompt=function(e){return true};
+@on_event   LOAD_ERROR    exit


### PR DESCRIPTION
adding the load_error event as a way to see if it is a good workaround for the TLS error on UZBL and allows assets to continue to load even if the browser encounters error.