### PR TITLE
Fix: work with nmcli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: python
 python:
   - "2.7"
+virtualenv:
+  system_site_packages: true
 addons:
   firefox: "45.0"
   apt:
     packages:
       - net-tools
       - mplayer
+      - python-gobject
       - python-setuptools
 before_install:
   - sudo add-apt-repository ppa:mc3man/trusty-media -y
@@ -35,7 +38,7 @@ before_script:
 
 script:
   - find . ! -path "*/rtmplite/*" -name \*.py -exec pep8 --ignore=E402,E501,E731 {} +
-  - nosetests -v -a '!fixme' --with-isolation
+  - nosetests -v -a '!fixme'
   - ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
   - python -m SimpleHTTPServer 8081 &
   - sleep 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
         net-tools \
         procps \
         python-dev \
+        python-gobject \
         python-imaging \
         python-netifaces \
         python-simplejson \
@@ -22,8 +23,10 @@ RUN apt-get update && \
 
 # Install Python requirements
 ADD requirements.txt /tmp/requirements.txt
+ADD requirements.dev.txt /tmp/requirements.dev.txt
 RUN curl -s https://bootstrap.pypa.io/get-pip.py | python && \
-    pip install -r /tmp/requirements.txt
+    pip install -r /tmp/requirements.txt && \
+    pip install -r /tmp/requirements.dev.txt
 
 # Create runtime user
 RUN useradd pi

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -1,3 +1,8 @@
+- name: Installs NetworkManager
+  apt:
+    name: network-manager
+    state: latest
+
 - name: Check if screenly-network-manager files exist
   stat:
     path: /usr/sbin/screenly_net_mgr.py
@@ -36,20 +41,15 @@
 
 # Use resin-wifi-connect if Stretch
 
-- debug:
-    msg: "Manage network: {{ manage_network }}"
-
 - name: Disable dhcpcd
   command: systemctl disable dhcpcd
   when:
     - ansible_distribution_major_version|int >= 9
-    - manage_network|bool == true
 
 - name: Activate NetworkManager
   command: systemctl enable NetworkManager
   when:
     - ansible_distribution_major_version|int >= 9
-    - manage_network|bool == true
 
 - name: Check if resin-wifi-connect required version exist
   stat:
@@ -67,7 +67,6 @@
   when:
     - ansible_distribution_major_version|int >= 9
     - not resin_wifi_version_file_exist
-    - manage_network|bool == true
 
 - name: Unarchive resin-wifi-connect release
   unarchive:
@@ -78,7 +77,6 @@
   when:
     - ansible_distribution_major_version|int >= 9
     - not resin_wifi_version_file_exist
-    - manage_network|bool == true
 
 - name: Copy "ui" folder
   copy:
@@ -88,7 +86,6 @@
   when:
     - ansible_distribution_major_version|int >= 9
     - not resin_wifi_version_file_exist
-    - manage_network|bool == true
 
 - name: Copy wifi-connect file
   copy:
@@ -98,7 +95,6 @@
   when:
     - ansible_distribution_major_version|int >= 9
     - not resin_wifi_version_file_exist
-    - manage_network|bool == true
 
 - name: Touch resin-wifi-connect version file
   file:
@@ -107,7 +103,6 @@
   when:
     - ansible_distribution_major_version|int >= 9
     - not resin_wifi_version_file_exist
-    - manage_network|bool == true
 
 - name: Remove unarchive files
   file:
@@ -120,60 +115,33 @@
   when:
     - ansible_distribution_major_version|int >= 9
     - not resin_wifi_version_file_exist
-    - manage_network|bool == true
 
 - name: Copy wifi-connect systemd unit
   copy:
     src: "wifi-connect.service"
     dest: "/etc/systemd/system/wifi-connect.service"
-  when: manage_network|bool == true
 
 - name: Enable wifi-connect systemd service
   systemd:
     name: wifi-connect.service
     enabled: yes
-  when: manage_network|bool == true
-
-- name: Remove disable_manage_network file
-  file:
-    state: absent
-    path: "/home/pi/.screenly/disable_manage_network"
-  when: manage_network|bool == true
-
-# Disable resin-wifi-connect
-
-# If disable_manage_network file exist the state is always "initialized".
-# To avoid changing the state the "Re-run network detection" button will be locked
-
-- name: Check if deprecated systemd services exists
-  stat:
-    path: /etc/systemd/system/wifi-connect.service
-  register: wifi_service
-
-- set_fact: wifi_service_exist="{{wifi_service.stat.exists}}"
-
-- name: Disable wifi-connect systemd service
-  systemd:
-    name: wifi-connect.service
-    enabled: no
-  when:
-    - manage_network|bool != true
-    - wifi_service_exist
-
-- name: Remove wifi-connect systemd unit
-  file:
-    state: absent
-    path: "/etc/systemd/system/wifi-connect.service"
-  when: manage_network|bool != true
 
 - name: Touch initialized file
   file:
     state: touch
     path: "/home/pi/.screenly/initialized"
-  when: manage_network|bool != true
 
-- name: Touch disable_manage_network file
-  file:
-    state: touch
-    path: "/home/pi/.screenly/disable_manage_network"
-  when: manage_network|bool != true
+- name: Add pi user to Identity
+  replace:
+    regexp: '^Identity=.*'
+    replace: 'Identity=unix-group:netdev;unix-group:sudo:pi'
+    dest: /var/lib/polkit-1/localauthority/10-vendor.d/org.freedesktop.NetworkManager.pkla
+
+- name: Set ResultAny to yes
+  replace:
+    regexp: '^ResultAny=.*'
+    replace: 'ResultAny=yes'
+    dest: /var/lib/polkit-1/localauthority/10-vendor.d/org.freedesktop.NetworkManager.pkla
+
+- name: Copy org.freedesktop.NetworkManager.pkla to 50-local.d
+  command: cp -f /var/lib/polkit-1/localauthority/10-vendor.d/org.freedesktop.NetworkManager.pkla /etc/polkit-1/localauthority/50-local.d

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -153,6 +153,7 @@
     - matchbox
     - omxplayer
     - python-dev
+    - python-gobject
     - python-netifaces
     - python-simplejson
     - rpi-update

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -2,8 +2,6 @@
   hosts: all
   user: pi
   become: yes
-  vars:
-    manage_network: "{{ lookup('env', 'MANAGE_NETWORK') }}"
 
   handlers:
     - name: restart-nginx

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -50,19 +50,6 @@ fi
 #Add reference of what linux flavor is running to OSE_version file
 cat /etc/os-release | grep "PRETTY_NAME" >> ~/OSE_version.md
 
-echo && read -p "Do you want Screenly to manage your network? This is recommended for most users. (Y/n)" -n 1 -r -s NETWORK && echo
-if [ "$NETWORK" == 'n' ]; then
-  export MANAGE_NETWORK=false
-else
-  dpkg -s network-manager > /dev/null 2>&1
-  if [ "$?" = "1" ]; then
-    echo -e "\n\nIt looks like NetworkManager is not installed. Please install it by running 'sudo apt install -y network-manager' and then re-run the installation."
-    exit 1
-  fi
-
-  export MANAGE_NETWORK=true
-fi
-
 echo && read -p "Would you like to perform a full system upgrade as well? (y/N)" -n 1 -r -s UPGRADE && echo
 if [ "$UPGRADE" != 'y' ]; then
   EXTRA_ARGS="--skip-tags enable-ssl,system-upgrade"

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -138,8 +138,7 @@ def nmcli_get_connections(pattern=None, pattern_ignore=None, fields=None, active
 
 def nmcli_remove_connection(connection):
     """
-    :param connection: str
-    :return: str
+    :param connection: string
     """
     try:
         sh.sudo.nmcli('c', 'delete', connection)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -120,7 +120,11 @@ def nmcli_get_connections(pattern=None, pattern_ignore=None, fields=None, active
     if active:
         params.append('--active')
 
-    out = sh.nmcli('-t', '-f', ','.join(fields), 'c', 'show', *params)
+    try:
+        out = sh.nmcli('-t', '-f', ','.join(fields), 'c', 'show', *params)
+    except sh.CommandNotFound:
+        return None
+
     connections = re.sub(escape_color_pattern, '', out.encode('utf-8')).splitlines()
 
     if pattern:
@@ -137,8 +141,10 @@ def nmcli_remove_connection(connection):
     :param connection: str
     :return: str
     """
-
-    return sh.sudo.nmcli('c', 'delete', connection)
+    try:
+        sh.sudo.nmcli('c', 'delete', connection)
+    except sh.CommandNotFound:
+        pass
 
 
 def get_video_duration(file):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ jinja2==2.10.1
 mixpanel==4.3.2
 netifaces==0.10.4
 pyasn1==0.1.8
+pydbus==0.6.0
 python-dateutil==2.4.2
 pytz==2012d
 pyzmq==16.0.2

--- a/server.py
+++ b/server.py
@@ -5,19 +5,21 @@ __author__ = "Screenly, Inc"
 __copyright__ = "Copyright 2012-2017, Screenly, Inc"
 __license__ = "Dual License: GPLv2 and Commercial License"
 
+import hashlib
+import json
+import pydbus
+import re
+import traceback
+import uuid
+from base64 import b64encode
 from datetime import timedelta
 from dateutil import parser as date_parser
 from functools import wraps
 from hurry.filesize import size
-import json
 from mimetypes import guess_type
 from os import getenv, makedirs, mkdir, path, remove, rename, statvfs, stat
 from sh import git
 from subprocess import check_output
-import traceback
-import uuid
-import hashlib
-from base64 import b64encode
 
 from flask import Flask, make_response, render_template, request, send_from_directory, url_for
 from flask_cors import CORS
@@ -33,7 +35,7 @@ from lib import db
 from lib import diagnostics
 from lib import queries
 
-from lib.utils import nmcli_get_connections, nmcli_remove_connection
+from lib.utils import get_active_connections, remove_connection
 from lib.utils import get_node_ip, get_node_mac_address
 from lib.utils import get_video_duration
 from lib.utils import download_video_from_youtube, json_dump
@@ -44,7 +46,6 @@ from lib.utils import is_demo_node
 from settings import auth_basic, CONFIGURABLE_SETTINGS, DEFAULTS, LISTEN, PORT, settings, ZmqPublisher, ZmqCollector
 
 HOME = getenv('HOME', '/home/pi')
-DISABLE_MANAGE_NETWORK = '.screenly/disable_manage_network'
 
 app = Flask(__name__)
 CORS(app)
@@ -975,22 +976,29 @@ class ResetWifiConfig(Resource):
         if path.isfile(file_path):
             remove(file_path)
 
-        wireless_connections = nmcli_get_connections(
-            'wlan*',
-            'ScreenlyOSE-*',
-            fields=['name', 'device', 'uuid'],
-            active=True
+        bus = pydbus.SystemBus()
+
+        pattern_include = re.compile("wlan*")
+        pattern_exclude = re.compile("ScreenlyOSE-*")
+
+        wireless_connections = filter(
+            lambda c: not pattern_exclude.search(str(c['Id'])),
+            filter(
+                lambda c: pattern_include.search(str(c['Devices'])),
+                get_active_connections(bus)
+            )
         )
+
         if wireless_connections is not None:
             device_uuid = None
 
             if len(wireless_connections) > 0:
-                _, _, device_uuid = wireless_connections[0].split(':')
+                device_uuid = wireless_connections[0].get('Uuid')
 
             if not device_uuid:
                 raise Exception('The device has no active connection.')
 
-            nmcli_remove_connection(device_uuid)
+            remove_connection(bus, device_uuid)
 
         return '', 204
 
@@ -1290,8 +1298,6 @@ def settings_page():
 
     context['user'] = settings['user']
     context['password'] = "password" if settings['password'] != "" else ""
-
-    context['reset_button_state'] = "disabled" if path.isfile(path.join(HOME, DISABLE_MANAGE_NETWORK)) else ""
 
     if not settings['user'] or not settings['password']:
         context['use_auth'] = False

--- a/server.py
+++ b/server.py
@@ -975,21 +975,22 @@ class ResetWifiConfig(Resource):
         if path.isfile(file_path):
             remove(file_path)
 
-        device_uuid = None
-
         wireless_connections = nmcli_get_connections(
             'wlan*',
             'ScreenlyOSE-*',
             fields=['name', 'device', 'uuid'],
             active=True
         )
-        if wireless_connections:
-            _, _, device_uuid = wireless_connections[0].split(':')
+        if wireless_connections is not None:
+            device_uuid = None
 
-        if not device_uuid:
-            raise Exception('The device has no active connection.')
+            if len(wireless_connections) > 0:
+                _, _, device_uuid = wireless_connections[0].split(':')
 
-        nmcli_remove_connection(device_uuid)
+            if not device_uuid:
+                raise Exception('The device has no active connection.')
+
+            nmcli_remove_connection(device_uuid)
 
         return '', 204
 

--- a/start_resin_wifi.py
+++ b/start_resin_wifi.py
@@ -30,11 +30,12 @@ if __name__ == "__main__":
 
     wireless_connections = nmcli_get_connections('wlan*', 'ScreenlyOSE-*', active=True)
 
-    if not wireless_connections and not gateways().get('default') and filter(r.match, interfaces()):
-        ssid = 'ScreenlyOSE-{}'.format(generate_perfect_paper_password(pw_length=4, has_symbols=False))
-        ssid_password = generate_perfect_paper_password(pw_length=8, has_symbols=False)
-        generate_page(ssid, ssid_password, 'screenly.io/wifi')
+    if not gateways().get('default') and filter(r.match, interfaces()):
+        if wireless_connections is None or len(wireless_connections) == 0:
+            ssid = 'ScreenlyOSE-{}'.format(generate_perfect_paper_password(pw_length=4, has_symbols=False))
+            ssid_password = generate_perfect_paper_password(pw_length=8, has_symbols=False)
+            generate_page(ssid, ssid_password, 'screenly.io/wifi')
 
-        wifi_connect = sh.sudo('wifi-connect', '-s', ssid, '-p', ssid_password, '-o', '9090')
+            wifi_connect = sh.sudo('wifi-connect', '-s', ssid, '-p', ssid_password, '-o', '9090')
     else:
         pass

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -275,7 +275,7 @@
                 network. <br><b>Warning:</b> after pressing, a reboot is required. Web interface will not be available
                 until reboot.</p>
             <div class="form-actions">
-                <button id="btn-reset" class="btn btn-primary" type="button" {{ context.reset_button_state }}>Re-run
+                <button id="btn-reset" class="btn btn-primary" type="button">Re-run
                     network detection
                 </button>
             </div>

--- a/tests/updates_test.py
+++ b/tests/updates_test.py
@@ -1,12 +1,13 @@
 from datetime import datetime
 from datetime import timedelta
 import unittest
-from mock import patch
-from settings import settings
+
+import mock
 import viewer
 import server
 import os
-import shutil
+
+from settings import settings
 
 fancy_sha = 'deadbeaf'
 
@@ -22,23 +23,31 @@ def mocked_req_get(*args, **kwargs):
 
 class UpdateTest(unittest.TestCase):
     def setUp(self):
-        settings.home = '/tmp/'
+        self.get_configdir_m = mock.patch('settings.ScreenlySettings.get_configdir', mock.MagicMock(return_value='/tmp/.screenly/'))
+        self.get_configdir_m.start()
+
         self.sha_file = settings.get_configdir() + 'latest_screenly_sha'
 
         if not os.path.exists(settings.get_configdir()):
             os.mkdir(settings.get_configdir())
 
     def tearDown(self):
-        shutil.rmtree(settings.get_configdir())
+        if os.path.isfile(self.sha_file):
+            os.remove(self.sha_file)
 
+        self.get_configdir_m.stop()
+
+    @mock.patch('viewer.settings.get_configdir', mock.MagicMock(return_value='/tmp/.screenly/'))
     def test_if_sha_file_not_exists__is_up_to_date__should_return_false(self):
         self.assertEqual(server.is_up_to_date(), True)
 
+    @mock.patch('viewer.settings.get_configdir', mock.MagicMock(return_value='/tmp/.screenly/'))
     def test_if_sha_file_not_equals_to_branch_hash__is_up_to_date__should_return_false(self):
         with open(self.sha_file, 'w+') as f:
             f.write(fancy_sha)
         self.assertEqual(server.is_up_to_date(), False)
 
+    @mock.patch('viewer.settings.get_configdir', mock.MagicMock(return_value='/tmp/.screenly/'))
     def test_if_sha_file_is_new__check_update__should_return_false(self):
         with open(self.sha_file, 'w+') as f:
             f.write(fancy_sha)
@@ -48,9 +57,10 @@ class UpdateTest(unittest.TestCase):
         with open(self.sha_file, 'r') as f:
             self.assertEqual(f.readline(), fancy_sha)
 
-    @patch('viewer.req_get', side_effect=mocked_req_get)
-    @patch('viewer.remote_branch_available', side_effect=lambda _: True)
-    @patch('viewer.fetch_remote_hash', side_effect=lambda _: 'master')
+    @mock.patch('viewer.req_get', side_effect=mocked_req_get)
+    @mock.patch('viewer.remote_branch_available', side_effect=lambda _: True)
+    @mock.patch('viewer.fetch_remote_hash', side_effect=lambda _: 'master')
+    @mock.patch('viewer.settings.get_configdir', mock.MagicMock(return_value='/tmp/.screenly/'))
     def test_if_sha_file_is_empty__check_update__should_return_true(self, req_get, remote_branch_available, fetch_remote_hash):
         with open(self.sha_file, 'w+') as f:
             pass

--- a/viewer.py
+++ b/viewer.py
@@ -480,13 +480,19 @@ def main():
 
     wireless_connections = nmcli_get_connections('wlan*', 'ScreenlyOSE-*', active=True)
 
-    if not wireless_connections and not path.isfile(HOME + INITIALIZED_FILE) and not gateways().get('default'):
-        url = 'http://{0}/hotspot'.format(LISTEN)
-        load_browser(url=url)
+    # Displays the hotspot page
+    if not path.isfile(HOME + INITIALIZED_FILE) and not gateways().get('default'):
+        if wireless_connections is None or len(wireless_connections) == 0:
+            url = 'http://{0}/hotspot'.format(LISTEN)
+            load_browser(url=url)
 
-        while not wireless_connections and not path.isfile(HOME + INITIALIZED_FILE) and not gateways().get('default'):
+    # Wait until the network is configured
+    while not path.isfile(HOME + INITIALIZED_FILE) and not gateways().get('default'):
+        if wireless_connections is None or len(wireless_connections) == 0:
             sleep(1)
             wireless_connections = nmcli_get_connections('wlan*', 'ScreenlyOSE-*', active=True)
+            continue
+        break
 
     wait_for_node_ip(5)
 

--- a/viewer.py
+++ b/viewer.py
@@ -1,30 +1,32 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
+import pydbus
+import random
+import re
+import sh
+import string
+import zmq
 from datetime import datetime, timedelta
+from mixpanel import Mixpanel, MixpanelException
+from netifaces import gateways
 from os import path, getenv, utime, system
 from platform import machine
 from random import shuffle
 from threading import Thread
-
-from mixpanel import Mixpanel, MixpanelException
-from netifaces import gateways
 from requests import get as req_get
 from signal import alarm, signal, SIGALRM, SIGUSR1
 from time import sleep
-import logging
-import random
-import sh
-import string
-import zmq
 
-from lib.errors import SigalrmException
-from settings import settings, LISTEN, PORT, ZmqConsumer
 import html_templates
-from lib.github import fetch_remote_hash, remote_branch_available
-from lib.utils import nmcli_get_connections, url_fails, touch, is_ci, get_node_ip
-from lib import db
+from settings import settings, LISTEN, PORT, ZmqConsumer
+
 from lib import assets_helper
+from lib import db
+from lib.github import fetch_remote_hash, remote_branch_available
+from lib.errors import SigalrmException
+from lib.utils import get_active_connections, url_fails, touch, is_ci, get_node_ip
 
 
 __author__ = "Screenly, Inc"
@@ -478,7 +480,18 @@ def wait_for_node_ip(seconds):
 def main():
     setup()
 
-    wireless_connections = nmcli_get_connections('wlan*', 'ScreenlyOSE-*', active=True)
+    bus = pydbus.SystemBus()
+
+    pattern_include = re.compile("wlan*")
+    pattern_exclude = re.compile("ScreenlyOSE-*")
+
+    wireless_connections = filter(
+        lambda c: not pattern_exclude.search(str(c['Id'])),
+        filter(
+            lambda c: pattern_include.search(str(c['Devices'])),
+            get_active_connections(bus)
+        )
+    )
 
     # Displays the hotspot page
     if not path.isfile(HOME + INITIALIZED_FILE) and not gateways().get('default'):
@@ -488,9 +501,18 @@ def main():
 
     # Wait until the network is configured
     while not path.isfile(HOME + INITIALIZED_FILE) and not gateways().get('default'):
-        if wireless_connections is None or len(wireless_connections) == 0:
+        if len(wireless_connections) == 0:
             sleep(1)
-            wireless_connections = nmcli_get_connections('wlan*', 'ScreenlyOSE-*', active=True)
+            wireless_connections = filter(
+                lambda c: not pattern_exclude.search(str(c['Id'])),
+                filter(
+                    lambda c: pattern_include.search(str(c['Devices'])),
+                    get_active_connections(bus)
+                )
+            )
+            continue
+        if wireless_connections is None:
+            sleep(1)
             continue
         break
 


### PR DESCRIPTION
These edits helps for users w/out network-manager
Refs #1100, https://github.com/Screenly/screenly-ose/issues/1094#issuecomment-488649624

But as I said here https://github.com/Screenly/screenly-ose/issues/1094#issuecomment-488661111
https://github.com/balena-io/wifi-connect uses NetworkManager. In other words, the user will not be able to configure the wireless network.

Sum up: Yes , this PR will help users without NetworkManager, but I think we need to make NetworkManager by default.
@vpetersson Need your opinion.

UPD: Our latest image already includes NetworkManager.