### PR TITLE
Remove bin from .dockerignore for balena push deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@ dist
 build
 eggs
 parts
-bin
 var
 sdist
 develop-eggs


### PR DESCRIPTION
When deploying the latest version of screenly to balenaCloud, if someone uses the `balena push` CLI deployment method, the CLI looks at `.dockerignore` and as such the `bin` directory which contains the `start-balena.sh` script is not copied. Removing `bin` from `.dockerignore` fixes this issue but I'm unsure if this breaks or conflicts with any other uses of this file.

Change-type: patch
Signed-off-by: Chris Crocker-White <chriscw@balena.io>