### PR TITLE
Allow connection to websocket when server is behind reverse proxy.

### DIFF
--- a/server.py
+++ b/server.py
@@ -19,6 +19,7 @@ from hurry.filesize import size
 from mimetypes import guess_type
 from os import getenv, makedirs, mkdir, path, remove, rename, statvfs, stat
 from subprocess import check_output
+from urlparse import urlparse
 
 from flask import Flask, make_response, render_template, request, send_from_directory, url_for
 from flask_cors import CORS
@@ -1193,7 +1194,7 @@ else:
 @auth_basic
 def viewIndex():
     player_name = settings['player_name']
-    my_ip = get_node_ip()
+    my_ip = urlparse(request.host_url).hostname
     is_demo = is_demo_node()
     resin_uuid = getenv("RESIN_UUID", None)
 


### PR DESCRIPTION
Currently the view index will generate an URL for the websocket, which is based on the physical address of the machine the server is running on. However when the server is running behind a reverse proxy like apache or nginx, we need to correct hostname in the request.

This pull request changes the generation of the websocket URL to use the hostname of the http request, which will be the ip if running natively without proxy and the hostname of the reverse proxy when being served through apache or nginx.