### PR TITLE
Edit: version of screenly in install.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
         git-core \
         libffi-dev \
         libssl-dev \
+        lsb-release \
         mplayer \
         net-tools \
         procps \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -18,6 +18,7 @@ RUN apt-get update && \
         python-netifaces \
         python-simplejson \
         libraspberrypi0 \
+        lsb-release \
         ifupdown \
         sqlite3 \
         uzbl \

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -102,7 +102,7 @@ sudo find /usr/share/locale -mindepth 1 -maxdepth 1 ! -name 'en*' ! -name 'de*' 
 
 cd ~/screenly && git rev-parse HEAD > ~/.screenly/latest_screenly_sha
 
-echo -e "Screenly version: $(git rev-parse --abbrev-ref HEAD)@$(git rev-parse HEAD)\n$(lsb_release -a)" > ~/version.md
+echo -e "Screenly version: $(git rev-parse --abbrev-ref HEAD)@$(git rev-parse --short HEAD)\n$(lsb_release -a)" > ~/version.md
 
 set +x
 echo "Installation completed."

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -102,7 +102,7 @@ sudo find /usr/share/locale -mindepth 1 -maxdepth 1 ! -name 'en*' ! -name 'de*' 
 
 cd ~/screenly && git rev-parse HEAD > ~/.screenly/latest_screenly_sha
 
-echo -e "Screenly version: $(git rev-parse --abbrev-ref HEAD)@$(git rev-parse HEAD)\n$(cat /etc/os-release | grep 'PRETTY_NAME')" > ~/version.md
+echo -e "Screenly version: $(git rev-parse --abbrev-ref HEAD)@$(git rev-parse HEAD)\n$(lsb_release -a)" > ~/version.md
 
 set +x
 echo "Installation completed."

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -34,21 +34,15 @@ if [ "$EXP" != 'y'  ]; then
   echo && read -p "Would you like to use the development branch? You will get the latest features, but things may break. (y/N)" -n 1 -r -s DEV && echo
   if [ "$DEV" != 'y'  ]; then
     export DOCKER_TAG="production"
-    echo "Screenly OSE version: Production" > ~/OSE_version.md
     BRANCH="production"
   else
     export DOCKER_TAG="latest"
-    echo "Screenly OSE version: Development" > ~/OSE_version.md
     BRANCH="master"
   fi
 else
   export DOCKER_TAG="experimental"
-  echo "Screenly OSE version: Experimental" > ~/OSE_version.md
   BRANCH="experimental"
 fi
-
-#Add reference of what linux flavor is running to OSE_version file
-cat /etc/os-release | grep "PRETTY_NAME" >> ~/OSE_version.md
 
 echo && read -p "Do you want Screenly to manage your network? This is recommended for most users because this adds features to manage your network. (Y/n)" -n 1 -r -s NETWORK && echo
 
@@ -107,6 +101,8 @@ sudo find /usr/share/locale -type f ! -name 'en' ! -name 'de*' ! -name 'es*' ! -
 sudo find /usr/share/locale -mindepth 1 -maxdepth 1 ! -name 'en*' ! -name 'de*' ! -name 'es*' ! -name 'ja*' ! -name 'fr*' ! -name 'zh*' -exec rm -r {} \;
 
 cd ~/screenly && git rev-parse HEAD > ~/.screenly/latest_screenly_sha
+
+echo -e "Screenly version: $(git rev-parse --abbrev-ref HEAD)@$(git rev-parse HEAD)\n$(cat /etc/os-release | grep 'PRETTY_NAME')" > ~/version.md
 
 set +x
 echo "Installation completed."


### PR DESCRIPTION
Ref https://github.com/Screenly/screenly-ose/pull/1139#discussion_r288925166
```
pi@raspberrypi:~ $ cat version.md 
Screenly version: master@76c881cc12a7ed93cf74547abec7961fe3a4bc18
PRETTY_NAME="Raspbian GNU/Linux 9 (stretch)"
```