### PR TITLE
Endpoint: PATCH on assets

### DIFF
--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -225,3 +225,32 @@ class DBHelperTest(unittest.TestCase):
         fetched = assets_helper.read(self.conn)
 
         self.assertEquals([0, 0, 0], [asset['play_order'] for asset in fetched])
+
+    def test_update_asset(self):
+        asset_x_ = assets_helper.create(self.conn, asset_x)
+        asset_x_copy = asset_x_.copy()
+        data = {'name': 'New name', 'mimetype': 'should not setted', 'empty': 'non exists field'}
+
+        self.assertEquals(asset_x_, asset_x_copy)
+
+        server.update_asset(asset_x_copy, data)
+        asset_x_copy = assets_helper.update(self.conn, asset_x_copy.get('id'), asset_x_copy)
+
+        self.assertEquals(asset_x_copy,
+                          {'is_enabled': 1,
+                           'asset_id': None,
+                           'end_date': datetime.datetime(2013, 1, 19, 23, 59),
+                           'is_active': 0,
+                           'duration': u'5',
+                           'is_processing': 0,
+                           'mimetype': u'web',
+                           'name': 'New name',
+                           'nocache': 0,
+                           'uri': u'http://www.wireload.net',
+                           'skip_asset_check': 0,
+                           'play_order': 1,
+                           'start_date': datetime.datetime(2013, 1, 16, 0, 0)
+                           }
+                          )
+
+        self.assertNotEqual(asset_x_, asset_x_copy)


### PR DESCRIPTION
Request on feature: #1195

Edits:
- The endpoint allows to PATCH all field except the following: asset_id, is_processing, mimetype, uri
- Added test `server_test.DBHelperTest.test_update_asset`
![изображение](https://user-images.githubusercontent.com/17593028/62110232-cc798080-b2cf-11e9-9864-1dd7e23abfb7.png)

