### PR TITLE
Edits: redis broker instead of rabbitmq

### DIFF
--- a/ansible/roles/screenly/files/screenly-celery.service
+++ b/ansible/roles/screenly/files/screenly-celery.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Screenly celery worker
-After=rabbitmq-server.service
+After=redis-server.service
 
 [Service]
 WorkingDirectory=/home/pi/screenly

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -154,7 +154,7 @@
       - python-gobject
       - python-netifaces
       - python-simplejson
-      - rabbitmq-server
+      - redis-server
       - rpi-update
       - sqlite3
       - systemd
@@ -174,6 +174,7 @@
       - lightdm
       - lightdm-gtk-greeter
       - dphys-swapfile
+      - rabbitmq-server
     state: absent
 
 - name: Perform system upgrade

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,7 +34,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.celery.dev
     depends_on:
-      - rabbitmq
+      - redis
       - screenly-server
     image: screenly-ose-celery
     network_mode: "host"
@@ -43,10 +43,11 @@ services:
       - screenly-volume:/home/pi/.screenly
       - screenly-assets-volume:/home/pi/screenly_assets
 
-  rabbitmq:
-    image: rabbitmq
-    command: rabbitmq-server
-    network_mode: "host"
+  redis:
+    restart: always
+    image: redis:alpine
+    expose:
+      - 6379
     logging:
       driver: none
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       dockerfile: docker/Dockerfile.celery.template
     depends_on:
       - screenly-server
-      - rabbitmq
+      - redis
     environment:
       - HOME=/data
       - PYTHONPATH=/data/screenly
@@ -62,12 +62,11 @@ services:
     volumes:
       - resin-data:/data
 
-  rabbitmq:
-    image: arm32v7/rabbitmq
-    command: rabbitmq-server
+  redis:
+    restart: always
+    image: arm32v7/redis
     ports:
-      - 5672:5672
-      - 15672:15672
+      - 6379:6379
 
 volumes:
     resin-data:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,6 +17,7 @@ gevent==1.2.2
 gunicorn==19.8.1
 hurry.filesize==0.9
 jinja2==2.10.1
+kombu==4.6.3  # cause of downgrade https://github.com/celery/kombu/issues/1063
 mixpanel==4.3.2
 netifaces==0.10.4
 pyasn1==0.1.8

--- a/server.py
+++ b/server.py
@@ -52,14 +52,20 @@ from lib.utils import is_balena_app, is_demo_node, is_wott_integrated, get_wott_
 from settings import CONFIGURABLE_SETTINGS, DEFAULTS, LISTEN, PORT, settings, ZmqPublisher, ZmqCollector
 
 HOME = getenv('HOME', '/home/pi')
-CELERY_RESULT_BACKEND = getenv('CELERY_RESULT_BACKEND', 'rpc://')
-CELERY_BROKER_URL = getenv('CELERY_BROKER_URL', 'amqp://')
+CELERY_RESULT_BACKEND = getenv('CELERY_RESULT_BACKEND', 'redis://localhost:6379/0')
+CELERY_BROKER_URL = getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+CELERY_TASK_RESULT_EXPIRES = timedelta(hours=6)
 
 app = Flask(__name__)
 CORS(app)
 api = Api(app, api_version="v1", title="Screenly OSE API")
 
-celery = Celery(app.name, backend=CELERY_RESULT_BACKEND, broker=CELERY_BROKER_URL)
+celery = Celery(
+    app.name,
+    backend=CELERY_RESULT_BACKEND,
+    broker=CELERY_BROKER_URL,
+    result_expires=CELERY_TASK_RESULT_EXPIRES
+)
 
 
 ################################


### PR DESCRIPTION
Edits: 
- Replaced rabbitmq by redis
- Fixed bug which was be the cause why we chosen rabbitmq
- celery result expires in 6 hours

Tested on:
- locally
- device
- balenaCloud

Screenshots:
![redis1](https://user-images.githubusercontent.com/17593028/68188253-f29b7480-ffd2-11e9-8bfe-e58ed9005f31.png)
![redis2](https://user-images.githubusercontent.com/17593028/68188255-f3340b00-ffd2-11e9-9f16-468ccaac0864.png)
![redis3](https://user-images.githubusercontent.com/17593028/68188257-f3340b00-ffd2-11e9-868b-573aaf600708.png)

Logs:
```
pi@raspberrypi:~/screenly $ celery -A server:celery status
worker@screenly: OK

1 node online.

```