### PR TITLE
Fix: requirements.txt and update command in install file

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -144,7 +144,7 @@ if [ ! -f /etc/locale.gen ]; then
 fi
 
 sudo sed -i 's/apt.screenlyapp.com/archive.raspbian.org/g' /etc/apt/sources.list
-sudo apt-get update
+sudo apt update -y
 sudo apt-get purge -y python-setuptools python-pip python-pyasn1
 sudo apt-get install -y python-dev git-core libffi-dev libssl-dev
 curl -s https://bootstrap.pypa.io/get-pip.py | sudo python

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ MarkupSafe==1.0
 ansible==2.8.2
 celery==4.3.0
 certifi==2018.4.16
-cffi==1.7.0
+cffi==1.13.2
 click==6.7
 configparser==3.5.0
 Flask-Cors==3.0.4
@@ -25,11 +25,12 @@ pydbus==0.6.0
 python-dateutil==2.4.2
 pytz==2012d
 pyzmq==16.0.2
+pyOpenSSL==19.1.0
 redis==3.2.0
-requests[security]==2.20.0
+requests[security]==2.22.0
 sh==1.08
 six==1.11.0
 uptime==2.0.2
-urllib3==1.25.1
+urllib3==1.25.7
 werkzeug==0.15.3
 youtube_dl>=2017.7.2


### PR DESCRIPTION
Edits:
- requirements.txt
- bin/install.sh

Some logs:
```
PLAY RECAP **************************************************************************************************************************************************************************************************
localhost                  : ok=87   changed=62   unreachable=0    failed=0    skipped=11   rescued=0    ignored=0   

+ sudo apt-get autoclean
Reading package lists... Done
Building dependency tree       
Reading state information... Done
+ sudo apt-get clean
+ sudo find /usr/share/doc -depth -type f '!' -name copyright -delete
+ sudo find /usr/share/doc -empty -delete
+ sudo rm -rf /usr/share/man /usr/share/groff /usr/share/info /usr/share/lintian /usr/share/linda /var/cache/man
+ sudo find /usr/share/locale -type f '!' -name en '!' -name 'de*' '!' -name 'es*' '!' -name 'ja*' '!' -name 'fr*' '!' -name 'zh*' -delete
+ sudo find /usr/share/locale -mindepth 1 -maxdepth 1 '!' -name 'en*' '!' -name 'de*' '!' -name 'es*' '!' -name 'ja*' '!' -name 'fr*' '!' -name 'zh*' -exec rm -r '{}' ';'
+ cd /home/pi/screenly
+ git rev-parse HEAD
+ sudo chown -R pi:pi /home/pi
+ '[' master = master ']'
+ sudo rm -f /etc/sudoers.d/010_pi-nopasswd
+ '[' master = master ']'
+ '[' false = false ']'
+ set +e
+ passwd
Changing password for pi.
Current password: 
passwd: Authentication token manipulation error
passwd: password unchanged
+ set -e
++ git rev-parse --abbrev-ref HEAD
++ git rev-parse --short HEAD
++ lsb_release -a
No LSB modules are available.
+ echo -e 'Screenly version: master@a1a764c\nDistributor ID:	Raspbian
Description:	Raspbian GNU/Linux 10 (buster)
Release:	10
Codename:	buster'
+ '[' false = false ']'
+ set +x
Installation completed.
You need to reboot the system for the installation to complete. Would you like to reboot now? (y/N)
```