### PR TITLE
Update main.yml

### DIFF
--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -176,6 +176,17 @@
       - dphys-swapfile
       - rabbitmq-server
     state: absent
+    
+- name: Remove cups/printing related packages
+  apt:
+    name:
+      - cups
+      - cups-browsed
+      - cups-client
+      - cups-common
+      - cups-daemon
+      - cups-server-common
+    state: absent
 
 - name: Perform system upgrade
   apt:


### PR DESCRIPTION
Remove cups related packages since screenly is not used for printing and these packages start services and daemon and is a waste of resources.