### PR TITLE
Update install.sh

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -165,6 +165,7 @@ sudo -E ansible-playbook site.yml $EXTRA_ARGS
 
 sudo apt-get autoclean
 sudo apt-get clean
+sudo apt autoremove -y
 sudo find /usr/share/doc -depth -type f ! -name copyright -delete
 sudo find /usr/share/doc -empty -delete
 sudo rm -rf /usr/share/man /usr/share/groff /usr/share/info /usr/share/lintian /usr/share/linda /var/cache/man


### PR DESCRIPTION
Cleaning up unused packages by running autoremove...

I noticed so many leftover packages from earlang and other lib packages when going from Screenly Image to EXP branch and then to DEV branch, I realize this is better than putting all the names in ansible after switching branches.. of course the package that requires these dependencies would need to be removed through ansible during installation depending which branch you choose, but again, it seems better to add one main package there and let the autoremove take care of rest, unless you think it is better to add all packages specifically in the ansible playbook.