### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,5 @@
 Mako==0.7.3
 MarkupSafe==1.0
-ansible==2.8.2
 celery==4.3.0
 certifi==2018.4.16
 cffi==1.13.2


### PR DESCRIPTION
ansible is already called for install on `install.sh` so no need to set here as well as it can conflict while the playbook is running.. (as rusko mentioned)