### PR TITLE
Use alpine base images

### DIFF
--- a/docker/Dockerfile.celery.template
+++ b/docker/Dockerfile.celery.template
@@ -7,8 +7,8 @@ RUN apk --no-cache add \
         libcec
 
 # Install Python requirements
-RUN curl -s https://bootstrap.pypa.io/get-pip.py | python
-RUN pip install \
+RUN curl -s https://bootstrap.pypa.io/get-pip.py | python2
+RUN pip2 install \
     celery-redbeat==0.13.0
 
 COPY . /tmp/screenly

--- a/docker/Dockerfile.celery.template
+++ b/docker/Dockerfile.celery.template
@@ -1,29 +1,15 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:jessie
+FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine
 
-RUN apt-get update && \
-    apt-get -y install \
-        build-essential \
+RUN apk --no-cache add \
+        build-core \
+        celery \
         curl \
-        git-core \
-        libffi-dev \
-        libssl-dev \
-        net-tools \
-        omxplayer \
-        psmisc \
-        python-dev \
-        python-gobject \
-        python-imaging \
-        python-netifaces \
-        python-simplejson \
-        libraspberrypi0 \
-        ifupdown \
-        sqlite3 && \
-    apt-get clean
+        libcec
 
 # Install Python requirements
-ADD requirements/requirements.txt /tmp/requirements.txt
-RUN curl -s https://bootstrap.pypa.io/get-pip.py | python && \
-    pip install --upgrade -r /tmp/requirements.txt
+RUN curl -s https://bootstrap.pypa.io/get-pip.py | python
+RUN pip install \
+    celery-redbeat==0.13.0
 
 COPY . /tmp/screenly
 

--- a/docker/Dockerfile.redis.template
+++ b/docker/Dockerfile.redis.template
@@ -2,4 +2,4 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine
 
 RUN apk --no-cache add redis
 
-CMD ["redis-server"]
+CMD ["redis-server", "--protected-mode", "no"]

--- a/docker/Dockerfile.redis.template
+++ b/docker/Dockerfile.redis.template
@@ -1,5 +1,5 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:jessie
+FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine
 
-RUN apt-get update && apt-get -y install redis-server && apt-get clean
+RUN apk --no-cache add redis
 
 CMD ["redis-server"]

--- a/docker/Dockerfile.websocket.template
+++ b/docker/Dockerfile.websocket.template
@@ -1,15 +1,13 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:jessie
+FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine
 
-RUN apt-get update && \
-    apt-get -y install \
-        build-essential \
+RUN apk --no-cache add \
+        build-base \
         curl \
-        python-dev && \
-    apt-get clean
+        python2-dev
 
 # Install Python requirements
-RUN curl -s https://bootstrap.pypa.io/get-pip.py | python
-RUN pip install \
+RUN curl -s https://bootstrap.pypa.io/get-pip.py | python2
+RUN pip2 install \
     flask==1.0.2 \
     gevent-websocket==0.10.1 \
     gevent==1.2.2 \


### PR DESCRIPTION
I tried to save some space and started to switch the containers to the alpine base images.

- [x] redis: 152MB --> 63MB
- [x] screenly-celery: 572MB --> 141MB
- [ ] screenly-server: 571MB
- [ ] screenly-viewer: 704MB
- [x] screenly-websocket: 343MB --> 272MB