### PR TITLE
Update screenly-viewer.service

### DIFF
--- a/ansible/roles/screenly/files/screenly-viewer.service
+++ b/ansible/roles/screenly/files/screenly-viewer.service
@@ -5,9 +5,19 @@ After=matchbox.service screenly-web.service
 [Service]
 WorkingDirectory=/home/pi/screenly
 User=pi
-MemoryLimit=60%
+
+# CPU Limits
+CPUAccounting=yes
+CPUQuota=100%
+CPUQuotaPeriodSec=60
+
+# Memory Limits
 MemoryAccounting=yes
+MemoryLimit=60%
+
+# Kill Signal control
 KillMode=control-group
+SendSIGHUP=yes
 
 Environment=DISPLAY=:0.0
 

--- a/ansible/roles/screenly/files/screenly-viewer.service
+++ b/ansible/roles/screenly/files/screenly-viewer.service
@@ -10,12 +10,13 @@ User=pi
 CPUAccounting=yes
 CPUQuota=100%
 
-# Memory Limits
+# Memory Limits as stopgap to prevent system lockup due to resource exhaustion
 MemoryAccounting=yes
-MemoryLimit=65%
+MemoryLimit=60%
 
 # Kill Signal control
 KillMode=control-group
+KillSignal=SIGKILL
 SendSIGHUP=yes
 
 Environment=DISPLAY=:0.0

--- a/ansible/roles/screenly/files/screenly-viewer.service
+++ b/ansible/roles/screenly/files/screenly-viewer.service
@@ -26,7 +26,7 @@ ExecStartPre=/usr/bin/xset -dpms
 ExecStartPre=/usr/bin/xset s noblank
 
 ExecStart=/usr/bin/python /home/pi/screenly/viewer.py
-Restart=on-failure
+Restart=always
 
 ExecStartPost=/bin/rm -f /tmp/uzbl_*
 ExecStartPost=/bin/rm -f /tmp/screenly_html/*

--- a/ansible/roles/screenly/files/screenly-viewer.service
+++ b/ansible/roles/screenly/files/screenly-viewer.service
@@ -5,19 +5,19 @@ After=matchbox.service screenly-web.service
 [Service]
 WorkingDirectory=/home/pi/screenly
 User=pi
+PrivateTmp=yes
 
 # CPU Limits
+Delegate=yes
 CPUAccounting=yes
-CPUQuota=100%
+LimitCPU=300s
 
-# Memory Limits as stopgap to prevent system lockup due to resource exhaustion
+# Memory Limits
 MemoryAccounting=yes
-MemoryLimit=60%
+MemoryLimit=65%
 
-# Kill Signal control
+# Process control
 KillMode=control-group
-KillSignal=SIGKILL
-SendSIGHUP=yes
 
 Environment=DISPLAY=:0.0
 
@@ -37,9 +37,13 @@ ExecStartPre=/usr/bin/xset s noblank
 
 ExecStart=/usr/bin/python /home/pi/screenly/viewer.py
 Restart=always
+RestartSec=5
+StartLimitInterval=30
+StartLimitBurst=3
 
-ExecStartPost=/bin/rm -f /tmp/uzbl_*
-ExecStartPost=/bin/rm -f /tmp/screenly_html/*
+# Not needed since using PrivateTmp
+#ExecStartPost=/bin/rm -f /tmp/uzbl_*
+#ExecStartPost=/bin/rm -f /tmp/screenly_html/*
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/screenly/files/screenly-viewer.service
+++ b/ansible/roles/screenly/files/screenly-viewer.service
@@ -38,7 +38,7 @@ ExecStartPre=/usr/bin/xset s noblank
 ExecStart=/usr/bin/python /home/pi/screenly/viewer.py
 Restart=always
 RestartSec=5
-StartLimitInterval=30
+StartLimitIntervalSec=60
 StartLimitBurst=3
 
 # Not needed since using PrivateTmp

--- a/ansible/roles/screenly/files/screenly-viewer.service
+++ b/ansible/roles/screenly/files/screenly-viewer.service
@@ -5,6 +5,9 @@ After=matchbox.service screenly-web.service
 [Service]
 WorkingDirectory=/home/pi/screenly
 User=pi
+MemoryLimit=65%
+MemoryAccounting=yes
+KillMode=mixed
 
 Environment=DISPLAY=:0.0
 

--- a/ansible/roles/screenly/files/screenly-viewer.service
+++ b/ansible/roles/screenly/files/screenly-viewer.service
@@ -5,9 +5,9 @@ After=matchbox.service screenly-web.service
 [Service]
 WorkingDirectory=/home/pi/screenly
 User=pi
-MemoryLimit=65%
+MemoryLimit=60%
 MemoryAccounting=yes
-KillMode=mixed
+KillMode=control-group
 
 Environment=DISPLAY=:0.0
 

--- a/ansible/roles/screenly/files/screenly-viewer.service
+++ b/ansible/roles/screenly/files/screenly-viewer.service
@@ -9,11 +9,10 @@ User=pi
 # CPU Limits
 CPUAccounting=yes
 CPUQuota=100%
-CPUQuotaPeriodSec=60
 
 # Memory Limits
 MemoryAccounting=yes
-MemoryLimit=60%
+MemoryLimit=65%
 
 # Kill Signal control
 KillMode=control-group


### PR DESCRIPTION
To prevent screenly-viewer from freezing the pi because of uzbl using too much memory when loading certain assets, we control the memory limits of the service. I was undecided as to which signal the KillMode should be set to, either default control-group or mixed, but since mixed accomplishes what control-group does in the end while sending different signals, I thought it'd be best to use that method.