### PR TITLE
Update screenly-celery.service

### DIFF
--- a/ansible/roles/screenly/files/screenly-celery.service
+++ b/ansible/roles/screenly/files/screenly-celery.service
@@ -9,9 +9,9 @@ ExecStart=/usr/local/bin/celery worker -A server.celery -B -n worker@screenly --
 Restart=always
 RestartSec=5
 
-# Memory Limits
+# Memory Limits as stopgap to prevent system lockup due to resource exhaustion
 MemoryAccounting=yes
-MemoryLimit=100M
+MemoryLimit=16%
 
 # Kill Signal control
 KillMode=control-group

--- a/ansible/roles/screenly/files/screenly-celery.service
+++ b/ansible/roles/screenly/files/screenly-celery.service
@@ -8,9 +8,14 @@ User=pi
 ExecStart=/usr/local/bin/celery worker -A server.celery -B -n worker@screenly --loglevel=info --schedule /home/pi/.screenly/celerybeat-schedule
 Restart=always
 RestartSec=5
-MemoryLimit=100M
+
+# Memory Limits
 MemoryAccounting=yes
+MemoryLimit=100M
+
+# Kill Signal control
 KillMode=control-group
+SendSIGHUP=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/screenly/files/screenly-celery.service
+++ b/ansible/roles/screenly/files/screenly-celery.service
@@ -8,7 +8,7 @@ User=pi
 ExecStart=/usr/local/bin/celery worker -A server.celery -B -n worker@screenly --loglevel=info --schedule /home/pi/.screenly/celerybeat-schedule
 Restart=always
 RestartSec=5
-MemoryLimit=50M
+MemoryLimit=100M
 MemoryAccounting=yes
 KillMode=control-group
 

--- a/ansible/roles/screenly/files/screenly-celery.service
+++ b/ansible/roles/screenly/files/screenly-celery.service
@@ -8,6 +8,9 @@ User=pi
 ExecStart=/usr/local/bin/celery worker -A server.celery -B -n worker@screenly --loglevel=info --schedule /home/pi/.screenly/celerybeat-schedule
 Restart=always
 RestartSec=5
+MemoryLimit=50M
+MemoryAccounting=yes
+KillMode=control-group
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Noticed celery would consume a lot of memory when Pi was left running screenly with many assets for many hours, so we can prevent this from eating up resources by also limiting the memory like with the viewer service. This time I left the KillMode as default.