### PR TITLE
Update install.sh

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -167,7 +167,7 @@ sudo apt-get autoclean
 sudo apt-get clean
 sudo find /usr/share/doc -depth -type f ! -name copyright -delete
 sudo find /usr/share/doc -empty -delete
-sudo rm -rf /usr/share/man /usr/share/groff /usr/share/info /usr/share/lintian /usr/share/linda /var/cache/man
+sudo rm -rf /usr/share/man /usr/share/groff /usr/share/info/* /usr/share/lintian /usr/share/linda /var/cache/man
 sudo find /usr/share/locale -type f ! -name 'en' ! -name 'de*' ! -name 'es*' ! -name 'ja*' ! -name 'fr*' ! -name 'zh*' -delete
 sudo find /usr/share/locale -mindepth 1 -maxdepth 1 ! -name 'en*' ! -name 'de*' ! -name 'es*' ! -name 'ja*' ! -name 'fr*' ! -name 'zh*' -exec rm -r {} \;
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -77,12 +77,6 @@ EOF
     fi
   fi
 
-  echo && read -p "Would you like to install the WoTT agent to help you manage security of your Raspberry Pi? (y/N)" -n 1 -r -s WOTT && echo
-  if [ "$WOTT" = 'y' ]; then
-      curl -s https://packagecloud.io/install/repositories/wott/agent/script.deb.sh | sudo bash
-      sudo apt install wott-agent
-  fi
-
   echo && read -p "Do you want Screenly to manage your network? This is recommended for most users because this adds features to manage your network. (Y/n)" -n 1 -r -s NETWORK && echo
 
   echo && read -p "Would you like to perform a full system upgrade as well? (y/N)" -n 1 -r -s UPGRADE && echo

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -158,7 +158,7 @@ fi
 
 sudo pip install ansible==2.8.2
 
-sudo -u pi ansible localhost -m git -a "repo=$REPOSITORY dest=/home/pi/screenly version=$BRANCH"
+sudo -u pi ansible localhost -m git -a "repo=$REPOSITORY dest=/home/pi/screenly version=$BRANCH force=yes"
 cd /home/pi/screenly/ansible
 
 sudo -E ansible-playbook site.yml $EXTRA_ARGS

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-clear;
-
 WEB_UPGRADE=false
 BRANCH_VERSION=
 MANAGE_NETWORK=
@@ -32,6 +30,9 @@ if [ "$WEB_UPGRADE" = false ]; then
     exit 1
   fi
 
+  # clear screen
+  clear;
+  
   # Set color of logo
   tput setaf 6
   tput bold
@@ -99,9 +100,9 @@ elif [ "$WEB_UPGRADE" = true ]; then
   fi
 
   if [ "$MANAGE_NETWORK" = false ]; then
-    NETWORK="y"
-  elif [ "$MANAGE_NETWORK" = true ]; then
     NETWORK="n"
+  elif [ "$MANAGE_NETWORK" = true ]; then
+    NETWORK="y"
   else
     echo -e "Invalid -n parameter."
     exit 1

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -156,6 +156,11 @@ sudo apt-get purge -y python-setuptools python-pip python-pyasn1
 sudo apt-get install -y python-dev git-core libffi-dev libssl-dev whois
 curl -s https://bootstrap.pypa.io/get-pip.py | sudo python
 
+# users who chose experimental and then reverted back to master or production need docker removed
+if [ "$BRANCH" != "experimental" ]; then
+	sudo apt-get purge -y docker-ce docker-ce-cli containerd.io > /dev/null
+fi
+
 if [ "$NETWORK" == 'y' ]; then
   export MANAGE_NETWORK=true
   sudo apt-get install -y network-manager

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -189,6 +189,9 @@ fi
 
 #######################################################################
 # Setup a new pi password if default password "raspberry" detected
+
+if [ "$BRANCH" = "master" ] || [ "$BRANCH" = "production" ] && [ "$WEB_UPGRADE" = false ]; then
+
 # clear any previous set variables used for password detection
 _CURRENTPISALT=''
 _CURRENTPIUSERPWD=''
@@ -199,15 +202,14 @@ _CURRENTPISALT=$(sudo cat /etc/shadow | grep pi | awk -F '$' '{print $3}')
 _CURRENTPIUSERPWD=$(sudo cat /etc/shadow | grep pi | awk -F ':' '{print $2}')
 _DEFAULTPIPWD=$(mkpasswd -m sha-512 raspberry $_CURRENTPISALT)
 
-if [[ "$_CURRENTPIUSERPWD" == "$_DEFAULTPIPWD" ]]; then
-echo "(Warning): The default raspberry pi password was detected! - please change it now..."
-  if [ "$BRANCH" = "master" ] || [ "$BRANCH" = "production" ] && [ "$WEB_UPGRADE" = false ]; then
-  set +e
-  passwd
-  set -e
+  if [[ "$_CURRENTPIUSERPWD" == "$_DEFAULTPIPWD" ]]; then
+    echo "(Warning): The default raspberry pi password was detected! - please change it now..."
+    set +e
+    passwd
+    set -e
+  else
+    echo "The default raspberry pi password was not detected, continuing with installation..."
   fi
-else
-  echo "The default raspberry pi password was not detected, continuing with installation..."
 fi
 #######################################################################
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -156,7 +156,7 @@ else
   export MANAGE_NETWORK=false
 fi
 
-sudo pip install ansible==2.8.2
+sudo pip install ansible==2.8.8
 
 sudo -u pi ansible localhost -m git -a "repo=$REPOSITORY dest=/home/pi/screenly version=$BRANCH force=yes"
 cd /home/pi/screenly/ansible

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -200,7 +200,7 @@ fi
 # Setup a new pi password if default password "raspberry" detected
 
 if [ "$BRANCH" = "master" ] || [ "$BRANCH" = "production" ] && [ "$WEB_UPGRADE" = false ]; then
-
+set +x
 # clear any previous set variables used for password detection
 _CURRENTPISALT=''
 _CURRENTPIUSERPWD=''
@@ -216,8 +216,10 @@ _DEFAULTPIPWD=$(mkpasswd -m sha-512 raspberry $_CURRENTPISALT)
     set +e
     passwd
     set -e
+    set -x
   else
     echo "The default raspberry pi password was not detected, continuing with installation..."
+    set -x
   fi
 fi
 #######################################################################


### PR DESCRIPTION
_force ansible dir downstream via override_

from experience, if users get errors during ansible installation, the entire installation fails, unless the force option is set here to override and pull down the fresh ansible dir from repo, they need to manually copy the entire ansible folder from github to their Pi using wget or curl.. that should not be, i dont see any reason why the master ansible repo should not be forced downstream on the device where screenly-ose is being installed.. if there is a reason i am missing please let me know, i cant think of one at the moment.