### PR TITLE
Fix: viewer should wait for server

### DIFF
--- a/ansible/roles/screenly/files/screenly-viewer.service
+++ b/ansible/roles/screenly/files/screenly-viewer.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Screenly Viewer
-After=matchbox.service screenly-web.service
+After=matchbox.service
 
 [Service]
 WorkingDirectory=/home/pi/screenly

--- a/viewer.py
+++ b/viewer.py
@@ -5,6 +5,8 @@ import logging
 import pydbus
 import random
 import re
+
+import requests
 import sh
 import string
 import zmq
@@ -539,6 +541,15 @@ def wait_for_node_ip(seconds):
             sleep(1)
 
 
+def wait_for_server(retries, wt=1):
+    for _ in range(retries):
+        try:
+            requests.get('http://{0}:{1}'.format(LISTEN, PORT))
+            break
+        except requests.exceptions.ConnectionError:
+            sleep(wt)
+
+
 def main():
     global db_conn, scheduler
     setup()
@@ -548,6 +559,8 @@ def main():
     subscriber.start()
 
     scheduler = Scheduler()
+
+    wait_for_server(5)
 
     if is_balena_app():
         load_browser()


### PR DESCRIPTION
Bug: 
- The viewer starts showing the hotspot page before the server starts. Thus the hotspot looks broken.