### PR TITLE
Update server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -416,9 +416,7 @@ def prepare_asset(request, unique_name=False):
     if not all([get('name'), get('uri'), get('mimetype')]):
         raise Exception("Not enough information provided. Please specify 'name', 'uri', and 'mimetype'.")
 
-    ampfix = "&amp;"
-    name = escape(get('name').replace(ampfix, '&'))
-    
+    name = escape(get('name'))
     if unique_name:
         with db.conn(settings['database']) as conn:
             names = assets_helper.get_names_of_assets(conn)
@@ -441,7 +439,7 @@ def prepare_asset(request, unique_name=False):
         'nocache': get('nocache'),
     }
 
-    uri = (get('uri')).replace(ampfix, '&').replace('<', '&lt;').replace('>', '&gt;').replace('\'', '&apos;').replace('\"', '&quot;')
+    uri = escape(get('uri').encode('utf-8'))
 
     if uri.startswith('/'):
         if not path.isfile(uri):
@@ -507,7 +505,8 @@ def prepare_asset_v1_2(request_environ, asset_id=None, unique_name=False):
         raise Exception(
             "Not enough information provided. Please specify 'name', 'uri', 'mimetype', 'is_enabled', 'start_date' and 'end_date'.")
 
-    name = escape(get('name'))
+    ampfix = "&amp;"
+    name = escape(get('name').replace(ampfix, '&'))
     if unique_name:
         with db.conn(settings['database']) as conn:
             names = assets_helper.get_names_of_assets(conn)
@@ -528,7 +527,7 @@ def prepare_asset_v1_2(request_environ, asset_id=None, unique_name=False):
         'nocache': get('nocache')
     }
 
-    uri = escape(get('uri'))
+    uri = (get('uri')).replace(ampfix, '&').replace('<', '&lt;').replace('>', '&gt;').replace('\'', '&apos;').replace('\"', '&quot;')
 
     if uri.startswith('/'):
         if not path.isfile(uri):

--- a/server.py
+++ b/server.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 __author__ = "Screenly, Inc"
-__copyright__ = "Copyright 2012-2019, Screenly, Inc"
+__copyright__ = "Copyright 2012-2020, Screenly, Inc"
 __license__ = "Dual License: GPLv2 and Commercial License"
 
 import json
@@ -416,7 +416,9 @@ def prepare_asset(request, unique_name=False):
     if not all([get('name'), get('uri'), get('mimetype')]):
         raise Exception("Not enough information provided. Please specify 'name', 'uri', and 'mimetype'.")
 
-    name = escape(get('name'))
+    ampfix = "&amp;"
+    name = escape(get('name').replace(ampfix, '&'))
+    
     if unique_name:
         with db.conn(settings['database']) as conn:
             names = assets_helper.get_names_of_assets(conn)
@@ -439,7 +441,7 @@ def prepare_asset(request, unique_name=False):
         'nocache': get('nocache'),
     }
 
-    uri = escape(get('uri').encode('utf-8'))
+    uri = (get('uri')).replace(ampfix, '&').replace('<', '&lt;').replace('>', '&gt;').replace('\'', '&apos;').replace('\"', '&quot;')
 
     if uri.startswith('/'):
         if not path.isfile(uri):


### PR DESCRIPTION
fixes:
- if escape was used in `uri`, the characters it was escaping to were preventing certain websites such as google slides from parsing parameters necessary for proper function, thus a manual replace had to be implemented to accomplish both needs (escaping while allowing `&` to be used properly)
- when escaping the name of the asset, if you make asset with `&` character inactive and active multiple times, the name starts having many duplicate instances of the word `amp;` (see screenshot)

![ampfix-needed-for-name](https://user-images.githubusercontent.com/24350198/96377893-a2bbac00-1156-11eb-9796-a28c86feed95.png)
