### PR TITLE
Update main.yml

### DIFF
--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -50,8 +50,8 @@
 
 - cron:
     name: Cleanup screenly_assets
-    minute: 0
-    hour: 1
+    minute: "0"
+    hour: "1"
     job: "/usr/local/bin/screenly_utils.sh cleanup"
     user: pi
 

--- a/ansible/roles/screenly/tasks/main.yml
+++ b/ansible/roles/screenly/tasks/main.yml
@@ -48,8 +48,9 @@
     owner: root
     group: root
 
-- cron:
-    name: Cleanup screenly_assets
+- name: Create screenly_assets cleanup cron job
+  cron:
+    name: "Cleanup screenly_assets"
     minute: "0"
     hour: "1"
     job: "/usr/local/bin/screenly_utils.sh cleanup"


### PR DESCRIPTION
just using to prevent warning:

```
TASK [screenly : cron] *****************************************************************************************************************************************************
[WARNING]: The value 0 (type int) in a string field was converted to u'0' (type string). If this does not look like what you expect, quote the entire value to ensure it
does not change.

[WARNING]: The value 1 (type int) in a string field was converted to u'1' (type string). If this does not look like what you expect, quote the entire value to ensure it
does not change.
```

From Ansible examples: (uses double quotes around integers)
```
- name: Ensure a job that runs at 2 and 5 exists. Creates an entry like "0 5,2 * * ls -alh > /dev/null"
  cron:
    name: "check dirs"
    minute: "0"
    hour: "5,2"
```