### PR TITLE
minor deprecation fix on Jessie block - master branch

### DIFF
--- a/ansible/roles/splashscreen/tasks/main.yml
+++ b/ansible/roles/splashscreen/tasks/main.yml
@@ -26,7 +26,6 @@
   when: ansible_distribution_major_version|int <= 7
 
 # If not Jessie
-
 - name: Remove older versions
   file:
     state: absent
@@ -42,11 +41,7 @@
 
 - name: Installs dependencies (not Jessie)
   apt:
-    name: "{{ packages }}"
-  vars:
-    packages:
-    - plymouth
-    - pix-plym-splash
+    name: plymouth
   when: ansible_distribution_major_version|int > 7
 
 - name: Copies plymouth theme

--- a/ansible/roles/splashscreen/tasks/main.yml
+++ b/ansible/roles/splashscreen/tasks/main.yml
@@ -3,8 +3,7 @@
 # If Jessie
 - name: Installs dependencies (Jessie)
   apt:
-    name:
-      - fbi
+    name: fbi
   when: ansible_distribution_major_version|int <= 7
 
 - name: Copies in splash screen
@@ -43,9 +42,11 @@
 
 - name: Installs dependencies (not Jessie)
   apt:
-    name:
-      - plymouth
-      - pix-plym-splash
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - plymouth
+    - pix-plym-splash
   when: ansible_distribution_major_version|int > 7
 
 - name: Copies plymouth theme


### PR DESCRIPTION
just minor fixes for handling deprecation warnings:

```
TASK [splashscreen : Installs dependencies (Jessie)] ***********************************************************************************************************************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name:
 "{{ item }}"`, please use `name: ['fbi']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
skipping: [localhost] => (item=[]) 


TASK [splashscreen : Installs dependencies (not Jessie)] *******************************************************************************************************************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name:
 "{{ item }}"`, please use `name: ['plymouth']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
ok: [localhost] => (item=[u'plymouth'])
```