### PR TITLE
Update plymouth related tasks and files

### DIFF
--- a/ansible/roles/splashscreen/files/plymouthd.default
+++ b/ansible/roles/splashscreen/files/plymouthd.default
@@ -2,4 +2,4 @@
 # upgrades.
 [Daemon]
 Theme=screenly
-ShowDelay=0
+ShowDelay=2

--- a/ansible/roles/splashscreen/tasks/main.yml
+++ b/ansible/roles/splashscreen/tasks/main.yml
@@ -61,10 +61,10 @@
 - name: Set plymouthd.default
   copy:
     src: plymouthd.default
-    dest: /usr/share/plymouth/plymouthd.default
+    dest: /usr/share/plymouth/plymouthd.defaults
   when: ansible_distribution_major_version|int > 7
   
-  - name: Copy to plymouthd.conf
+- name: Copy to plymouthd.conf
   copy:
     src: plymouthd.default
     dest: /etc/plymouth/plymouthd.conf

--- a/ansible/roles/splashscreen/tasks/main.yml
+++ b/ansible/roles/splashscreen/tasks/main.yml
@@ -63,3 +63,10 @@
     src: plymouthd.default
     dest: /usr/share/plymouth/plymouthd.default
   when: ansible_distribution_major_version|int > 7
+  
+  - name: Copy to plymouthd.conf
+  copy:
+    src: plymouthd.default
+    dest: /etc/plymouth/plymouthd.conf
+  when: ansible_distribution_major_version|int > 7
+  

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -81,6 +81,15 @@
   tags:
     - touches_boot_partition
 
+- name: Plymouth ignore serial consoles
+  replace:
+    dest: /boot/cmdline.txt
+    regexp: (^(?!$)((?!plymouth.ignore-serial-consoles).)*$)
+    replace: \1 plymouth.ignore-serial-consoles
+  when: not is_berryboot and ansible_distribution_major_version|int >= 7
+  tags:
+    - touches_boot_partition
+
 - name: Use Systemd as init and quiet boot process
   replace:
     dest: /boot/cmdline.txt


### PR DESCRIPTION
- Pi4 splashscreen fix

so I just installed master branch a few mins ago to start testing this again and looked at that file, the ShowDelay=0 that was originally supposed to be configured was not there at all, it was as if the file kept the original content and this file did not override it.. then I noticed this ShowDelay=2 was in the `/usr/share/plymouth/plymouthd.default` file and not in the `/etc/plymouth/plymouthd.conf` file.. which is the file that seems to mainly controls this.. meaning, I thought the /usr/share/ one would override the default one, but if I rename the default and restart, there is no splashscreen, which means the /etc/ one is the one that controls this so we should be editing that one instead.. plus this /etc/ location one gets called first from reading playmouth stream logs..

So, when I delete the /etc/plymouth.plymouthd.conf file, and re-run the plymouth set default theme of screenly, it only puts the [Daemon] and Theme=screenly on the default plymouthd.conf file, which is incorrect to show splashscreen, because we need the ShowDelay=2 line which has shown to work when set.

Reading the plymouth manual, it seems like we dont need to add the command to update the initramfs because the -R option is for this and rebuilds it for us.

.

doing more troubleshooting, running plymouthd --debug and seeing logs, the plymouth program calls for:
`load_settings:Trying to load /usr/share/plymouth//plymouthd.defaults`

but we seem to be placing a file named `dest: /usr/share/plymouth/plymouthd.default` via ansible task..
notice the missing `s` at end.. this is not a big deal, but we should properly name it so that it replaces the themes default.

.

finally got something specific, screenly splashscreen wouldn't come on, I had used the reinstall plymouth package method to get it working again at some point, then kept testing different modifications and changes so that I can know everything that effects it, and I checked `cmdline.txt` and noticed `plymouth.ignore-serial-consoles` was missing, so I added it, reset plymouth, set theme to screenly with rebuilt parameter -R, rebooted, splashscreen came back.. to be sure I changed to theme to `tribar` and it worked as well, removed the `plymouth.ignore-serial-consoles` line from `cmdline.txt` and no more splashscreen for tribar theme either.. put it back, came back.. so I think these tweaks make it that we try all we can to make sure plymouth has all needed config and changes..