### PR TITLE
Update requirements.host.txt

### DIFF
--- a/requirements/requirements.host.txt
+++ b/requirements/requirements.host.txt
@@ -1,2 +1,3 @@
 docker==4.3.1
 docker-compose==1.26.2
+pydbus==0.6.0


### PR DESCRIPTION
Started troubleshooting, first errors on logs were:
```
Dec 03 02:09:35 pi3dev python[470]: Traceback (most recent call last):
Dec 03 02:09:35 pi3dev python[470]:   File "/home/pi/screenly/start_resin_wifi.py", line 4, in <module>
Dec 03 02:09:35 pi3dev python[470]:     import pydbus
Dec 03 02:09:35 pi3dev python[470]: ImportError: No module named pydbus
Dec 03 02:09:35 pi3dev systemd[1]: wifi-connect.service: Main process exited, code=exited, status=1/FAILURE
Dec 03 02:09:35 pi3dev systemd[1]: wifi-connect.service: Failed with result 'exit-code'.
Dec 03 02:09:35 pi3dev systemd[1]: Failed to start Wifi Connect.
```
