### PR TITLE
Update main.yml

### DIFF
--- a/ansible/roles/screenly/vars/main.yml
+++ b/ansible/roles/screenly/vars/main.yml
@@ -8,3 +8,4 @@ deprecated_screenly_systemd_units:
   - screenly-viewer.service
   - X.service
   - matchbox.service
+  - wifi-connect.service


### PR DESCRIPTION
remove deprecated `wifi-connect.service`

Logs showed service was trying to start:
```
Dec 03 02:09:35 pi3dev python[470]: Traceback (most recent call last):
Dec 03 02:09:35 pi3dev python[470]:   File "/home/pi/screenly/start_resin_wifi.py", line 4, in <module>
Dec 03 02:09:35 pi3dev python[470]:     import pydbus
Dec 03 02:09:35 pi3dev python[470]: ImportError: No module named pydbus
Dec 03 02:09:35 pi3dev systemd[1]: wifi-connect.service: Main process exited, code=exited, status=1/FAILURE
Dec 03 02:09:35 pi3dev systemd[1]: wifi-connect.service: Failed with result 'exit-code'.
Dec 03 02:09:35 pi3dev systemd[1]: Failed to start Wifi Connect.
```

Rusko said to make part of deprecated: https://github.com/Screenly/screenly-ose/pull/1432