### PR TITLE
Update requirements.viewer.txt to specify urllib3 version

### DIFF
--- a/requirements/requirements.viewer.txt
+++ b/requirements/requirements.viewer.txt
@@ -12,3 +12,4 @@ pyzmq==19.0.2
 requests[security]==2.24.0
 sh==1.8
 uptime==3.0.1
+urllib3==1.25.11


### PR DESCRIPTION
Should we make this `urllib3==1.25.11` change because of this error when building dockerfile.viewer alert?

```
Step 3/15 : ADD requirements/requirements.viewer.txt /tmp/requirements.txt
 ---> 393dbe215b07
Step 4/15 : RUN pip install --no-cache-dir -r /tmp/requirements.txt
 ---> Running in 2855e7a14bd5
...
...
requests 2.24.0 has requirement urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1, but you'll have urllib3 1.26.2 which is incompatible.
```