### PR TITLE
Fix: displaying local images

### DIFF
--- a/webview/README.md
+++ b/webview/README.md
@@ -52,3 +52,9 @@ You can enable QT debugging by using the following:
 ```
 export QT_LOGGING_RULES=qt.qpa.*=true
 ```
+
+## Viewer arguments
+
+####--disable-web-security
+It's a temporary solution for `View::loadImage` when displaying local images. Without the flag, we will have the `js: Not allowed to load local resource:` error.<br/>
+Resource: https://forum.qt.io/topic/80431/not-allowed-load-local-resources-qtwebengine-disable-web-security

--- a/webview/src/main.cpp
+++ b/webview/src/main.cpp
@@ -8,7 +8,17 @@
 
 int main(int argc, char *argv[])
 {
-    QApplication app(argc, argv);
+    // @TODO: This is a temporary solution until we find something better
+    char ARG_DISABLE_WEB_SECURITY[] = "--disable-web-security";
+    int newArgc = argc+1+1;
+    char** newArgv = new char*[newArgc];
+    for(int i=0; i<argc; i++) {
+        newArgv[i] = argv[i];
+    }
+    newArgv[argc] = ARG_DISABLE_WEB_SECURITY;
+    newArgv[argc+1] = nullptr;
+
+    QApplication app(newArgc, newArgv);
 
     QCursor cursor(Qt::BlankCursor);
     QApplication::setOverrideCursor(cursor);


### PR DESCRIPTION
Fix: displaying local images with a new webview

Edits:
- Passing `--disable-web-security` to an application