### PR TITLE
Update server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -436,7 +436,7 @@ def prepare_asset(request, unique_name=False):
         'asset_id': get('asset_id'),
         'is_enabled': get('is_enabled'),
         'is_processing': get('is_processing'),
-        'nocache': get('nocache'),
+        'nocache': get('nocache')
     }
 
     uri = escape(get('uri').encode('utf-8'))
@@ -523,6 +523,7 @@ def prepare_asset_v1_2(request_environ, asset_id=None, unique_name=False):
     asset = {
         'name': name,
         'mimetype': get('mimetype'),
+        'asset_id': get('asset_id'),
         'is_enabled': get('is_enabled'),
         'nocache': get('nocache')
     }
@@ -536,7 +537,7 @@ def prepare_asset_v1_2(request_environ, asset_id=None, unique_name=False):
         if not validate_url(uri):
             raise Exception("Invalid URL. Failed to add asset.")
 
-    if not asset_id:
+    if not asset['asset_id']:
         asset['asset_id'] = uuid.uuid4().hex
         if uri.startswith('/'):
             rename(uri, path.join(settings['assetdir'], asset['asset_id']))


### PR DESCRIPTION
fixes API v1.2 missing `asset_id` parameter like used in API v1 which would allow custom asset_id to be used when using API and POST requests..

@rusko124 if you have any objection to this pls let me know why, I followed your prepare_asset function for `if not asset_id` from version 1, I am trying to create some custom dashboard control and scripts that allows me to enable/disable all assets by running through loop that I customized with asset_id's named like:
`male_ads_randomtext1`
`male_ads_randomtext2`
`female_ads_randomtext1`
`female_ads_randomtext2`

Which will allow a developer that is creating some API calls to use the wildcard or preface regex such as `male_ads_` for example just like you use "default_" for default assets YAML file, and so this allows a customized API call that can enable or disable all tagged assets based on the regex/wildcard that the developer creates themselves..
Again, this is just allowing the asset_id to be customized upon a POST API call/request. When the asset_id is not given on the --data JSON request, it automatically creates it, and if it already exists it gives you error from SQL constraint, so I think all bases are covered.

Thoughts against this?

Thanks.

---
Just a screenshot of what I mean about building a custom dashboard:
![Screen Shot 2020-12-16 at 3 22 05 AM](https://user-images.githubusercontent.com/24350198/102323052-fdeafe80-3f4d-11eb-8fce-15997e2c7add.png)
