### PR TITLE
Enable cgroup in kernel for containerd

### DIFF
--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -132,6 +132,24 @@
   tags:
     - touches_boot_partition
 
+- name: cgroup_enable required by containerd for OOM
+  replace:
+    dest: /boot/cmdline.txt
+    regexp: (^(?!$)((?!cgroup_enable=memory).)*$)
+    replace: \1 cgroup_enable=memory
+  when: not is_berryboot and ansible_distribution_major_version|int >= 7
+  tags:
+    - touches_boot_partition
+
+- name: cgroup_memory required by containerd for OOM
+  replace:
+    dest: /boot/cmdline.txt
+    regexp: (^(?!$)((?!cgroup_memory=1).)*$)
+    replace: \1 cgroup_memory=1
+  when: not is_berryboot and ansible_distribution_major_version|int >= 7
+  tags:
+    - touches_boot_partition
+
 # Sometimes in some packages there are no necessary files.
 # They are required to install pip dependencies.
 # In this case we need to reinstall the packages.


### PR DESCRIPTION
Containerd requires cgroup memory enabled

See https://github.com/Screenly/screenly-ose/issues/1460