### PR TITLE
remove dummy package libgles2-mesa

### DIFF
--- a/docker/Dockerfile.viewer
+++ b/docker/Dockerfile.viewer
@@ -24,7 +24,6 @@ RUN apt-get update && \
         libfreetype6-dev \
         libgbm-dev \
         libgcrypt20-dev \
-        libgles2-mesa \
         libgles2-mesa-dev \
         libglib2.0-dev \
         libgst-dev \


### PR DESCRIPTION
I know it's just one package for now and the cleanup of all is long process, but one less to do..

```
libgles2-mesa:
transitional dummy package
This is a transitional dummy package, it can be safely removed.


File list of package libgles2-mesa in buster of architecture armhf:
/usr/share/bug/libgles2-mesa/control
/usr/share/bug/libgles2-mesa/script
/usr/share/doc/libgles2-mesa/changelog.Debian.gz
/usr/share/doc/libgles2-mesa/copyright


File list of package libgles2-mesa-dev in buster of architecture armhf:
/usr/include/GLES2/gl2.h
/usr/include/GLES2/gl2ext.h
/usr/include/GLES2/gl2platform.h
/usr/include/GLES3/gl3.h
/usr/include/GLES3/gl31.h
/usr/include/GLES3/gl32.h
/usr/include/GLES3/gl3ext.h
/usr/include/GLES3/gl3platform.h
/usr/lib/arm-linux-gnueabihf/pkgconfig/glesv2.pc
/usr/share/bug/libgles2-mesa-dev/control
/usr/share/bug/libgles2-mesa-dev/script
/usr/share/doc/libgles2-mesa-dev/changelog.Debian.gz
/usr/share/doc/libgles2-mesa-dev/copyright
```