### PR TITLE
requirements.host needs specific pyrsistent version

### DIFF
--- a/requirements/requirements.host.txt
+++ b/requirements/requirements.host.txt
@@ -1,3 +1,4 @@
 ansible==2.8.8
 docker==4.3.1
 docker-compose==1.26.2
+pyrsistent==0.15.7


### PR DESCRIPTION
need to specify version of pyrsistent because newer version is not compatible with python 2.7
pyrsistent installs as dependency of `jsonschema` which is auto installed as dependency of `docker-compose`

```
(from jsonschema<4,>=2.5.1->docker-compose==1.26.2->-r /home/pi/screenly/requirements/requirements.host.txt (line 3))\n  Downloading https://files.pythonhosted.org/packages/7d/ae/90ddcf28fb8eee5d4990920586d2856342e42faa95f39223f0b9762ef264/pyrsistent-0.17.2.tar.gz (106kB)\n\n:stderr: pyrsistent requires Python '>=3.5' but the running Python is 2.7.16\n"}
```