### PR TITLE
Update upgrade_containers.sh

### DIFF
--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -24,6 +24,9 @@ else
     export DEVICE_TYPE="pi1"
 fi
 
+# Restart docker.service so clear potential errors
+sudo systemctl restart docker.service
+
 sudo -E docker-compose \
     -f /home/pi/screenly/docker-compose.yml \
     -f /home/pi/screenly/docker-compose.override.yml \

--- a/bin/upgrade_containers.sh
+++ b/bin/upgrade_containers.sh
@@ -24,7 +24,7 @@ else
     export DEVICE_TYPE="pi1"
 fi
 
-# Restart docker.service so clear potential errors
+# Restart docker.service to clear potential errors
 sudo systemctl restart docker.service
 
 sudo -E docker-compose \


### PR DESCRIPTION
minor fix for potential container error during docker-compose `up -d`

logs from recent troubleshooting below:
```
pi@rpi3blk:~ $ ./quickinstall.sh 
# Running ./quickinstall.sh..

# Stopping all containers..
7f268486b860
82c1f31cfa53
35a4e465c65e
35e48647d443
7e9dee1ab13f
77cc9a3d5e7c
84281432d12a

# Running docker compose..
Pulling redis              ... done
Pulling srly-ose-server    ... done
Pulling srly-ose-websocket ... done
Pulling srly-ose-nginx     ... done
Pulling srly-ose-celery    ... done
Pulling srly-ose-viewer    ... done
Removing screenly_srly-ose-viewer_1
Starting screenly_redis_1                          ... done
Starting screenly_srly-ose-server_1 ... done
Recreating 84281432d12a_screenly_srly-ose-viewer_1 ... error
Starting screenly_srly-ose-websocket_1             ... done
Starting screenly_srly-ose-celery_1                ... done
Starting screenly_srly-ose-nginx_1                 ... done

ERROR: for 84281432d12a_screenly_srly-ose-viewer_1  You cannot remove a running container 84281432d12af2d2e8719d1129c3d03413e5f39f1e05bee59478be4dd7ed4b7b. Stop the container before attempting removal or force remove

ERROR: for srly-ose-viewer  You cannot remove a running container 84281432d12af2d2e8719d1129c3d03413e5f39f1e05bee59478be4dd7ed4b7b. Stop the container before attempting removal or force remove
ERROR: Encountered errors while bringing up the project.

# Cleaning up..
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Total reclaimed space: 0B
Reading package lists... Done
Building dependency tree       
Reading state information... Done
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```

___

_just for reference:_
contents of this "quickinstall.sh" script used for troubleshooting any docker-compose or dockerfile changes:
```
#!/bin/bash

echo "# Running $0.."
export MY_IP=$(ip -4 route get 8.8.8.8 | awk {'print $7'} | tr -d '\n')
TOTAL_MEMORY_KB=$(grep MemTotal /proc/meminfo | awk {'print $2'})
export VIEWER_MEMORY_LIMIT_KB=$(echo "$TOTAL_MEMORY_KB" \* 0.7 | bc)

# Hard code this to latest for now.
export DOCKER_TAG="latest"

if grep -qF "Raspberry Pi 4" /proc/device-tree/model; then
  export DEVICE_TYPE="pi4"
elif grep -qF "Raspberry Pi 3" /proc/device-tree/model; then
  export DEVICE_TYPE="pi3"
elif grep -qF "Raspberry Pi 2" /proc/device-tree/model; then
  export DEVICE_TYPE="pi2"
else
  export DEVICE_TYPE="pi1"
fi

echo -e "\n# Restarting docker service to clear potential errors.." && sudo systemctl restart docker.service
echo -e "\n# Stopping all containers.." && docker container stop $(docker container ls -aq)

echo -e "\n# Running docker compose.."
sudo -E docker-compose \
    -f /home/pi/screenly/docker-compose.yml \
    -f /home/pi/screenly/docker-compose.override.yml \
    pull

sudo -E docker-compose \
    -f /home/pi/screenly/docker-compose.yml \
    -f /home/pi/screenly/docker-compose.override.yml \
    up -d

echo -e "\n# Cleaning up.."
sudo apt-get autoclean
sudo apt-get clean
sudo docker system prune -f
sudo apt autoremove -y

echo -e "\n# Ready to reboot.."
read -p "Reboot now?" -n 1 -r -s REBOOTANS
if [[ "$REBOOTANS" == "y" ]]; then
 sudo reboot;
else
 echo -e "\nReboot aborted, remember to reboot in order for changes to take effect."
fi
```