### PR TITLE
Update nginx.conf

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -75,6 +75,15 @@ server {
 
         alias /data/screenly_assets;
     }
+    
+    location /static_with_mime {                                    
+        allow 10.0.0.0/16;                                          
+        allow 172.16.0.0/12;                                        
+        allow 192.168.0.0/16;                                       
+        deny all;                                                   
+                                                                    
+        alias /data/screenly/static;                                
+    }
 }
 
 server {


### PR DESCRIPTION
allow all private subnets to download backup file..

part of fixes for reported issue: https://github.com/Screenly/screenly-ose/issues/1490