### PR TITLE
Fix startup of nginx after base image changes

### DIFF
--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -12,6 +12,7 @@ ENV GIT_SHORT_HASH=$GIT_SHORT_HASH
 ARG GIT_BRANCH
 ENV GIT_BRANCH=$GIT_BRANCH
 
-COPY docker/nginx/nginx.conf /etc/nginx/conf.d/srly-ose.conf
+COPY docker/nginx/nginx.conf /etc/nginx/sites-enabled/srly-ose.conf
+RUN rm -f /etc/nginx/sites-enabled/default
 
-CMD nginx
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This commit fixes an issue where the nginx container does not start
as a result of the nginx packaged with raspbian daemonizing by default,
as well as including a conflicting virtualhost config from under /etc/nginx/sites-enabled.

Therefore, this change disables nginx daemonizing
in identical manner to the nginx upstream docker containers
(https://github.com/nginxinc/docker-nginx/blob/master/Dockerfile-debian.template#L106)
as well as removes the package default nginx virtualhost configuration.

Fixes #1504 