### PR TITLE
Implement reboot and shutdown for Dockerized Screenly via host agent

### DIFF
--- a/ansible/roles/screenly/files/screenly-host-agent.service
+++ b/ansible/roles/screenly/files/screenly-host-agent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Screenly Host Agent
+After=docker.service
+StartLimitIntervalSec=10
+StartLimitBurst=3
+
+[Service]
+WorkingDirectory=/home/pi/screenly
+User=pi
+
+ExecStart=/usr/bin/python3 /home/pi/screenly/host_agent.py
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/screenly/vars/main.yml
+++ b/ansible/roles/screenly/vars/main.yml
@@ -1,5 +1,6 @@
 screenly_systemd_units:
   - udev-restart.service
+  - screenly-host-agent.service
 
 deprecated_screenly_systemd_units:
   - screenly-celery.service

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -173,31 +173,13 @@
     update_cache: yes
   when: not cdefs_exist
 
-- name: Check if cc1plus exists
-  stat:
-    path: /usr/lib/gcc/arm-linux-gnueabihf/4.9/cc1plus
-  register: cc1plus
-
-- set_fact: cc1plus_exist="{{cc1plus.stat.exists}}"
-
-- name: Remove build-essential
-  apt:
-    name: build-essential
-    state: absent
-  when: not cc1plus_exist
-
-- name: Install build-essential
-  apt:
-    name: build-essential
-    state: present
-    update_cache: yes
-  when: not cc1plus_exist
-
 - name: Install Screenly dependencies
   apt:
     name:
       - rpi-update
       - bc
+      - python3
+      - python3-redis
     state: latest
 
 - name: Remove deprecated apt dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.redis
+    ports:
+      - 127.0.0.1:6379:6379
     restart: always
     volumes:
       - redis-data:/var/lib/redis

--- a/host_agent.py
+++ b/host_agent.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+__author__ = "Nash Kaminski"
+__license__ = "Dual License: GPLv2 and Commercial License"
+
+import logging
+import os
+import redis
+import subprocess
+
+# Name of redis channel to listen to
+CHANNEL_NAME = b'hostcmd'
+
+# Explicit command whitelist for security reasons, keys as bytes objects
+CMD_TO_ARGV = {b'reboot': ['/usr/bin/sudo', '-n', '/usr/bin/systemctl', 'reboot'],
+               b'shutdown': ['/usr/bin/sudo', '-n', '/usr/bin/systemctl', 'poweroff']}
+
+def execute_host_command(cmd_name):
+    cmd = CMD_TO_ARGV.get(cmd_name, None)
+    if cmd is None:
+        logging.warning("Unable to perform host command %s: no such command!", cmd_name)
+    elif os.getenv('TESTING'):
+        logging.warning("Would have executed %s but not doing so as TESTING is defined", cmd)
+    else:
+        logging.info("Executing host command %s", cmd_name)
+        phandle = subprocess.run(cmd)
+        logging.info("Host command %s (%s) returned %s", cmd_name, cmd, phandle.returncode)
+
+def process_message(message):
+    if (message.get('type', '') == 'message' and message.get('channel', b'') == CHANNEL_NAME):
+        execute_host_command(message.get('data', b''))
+    else:
+        logging.info("Received unsolicited message: %s", message)
+
+def subscriber_loop():
+    # Connect to redis on localhost and wait for messages
+    logging.info("Connecting to redis...")
+    rdb = redis.Redis(host="127.0.0.1", port=6379, db=0)
+    pubsub = rdb.pubsub(ignore_subscribe_messages=True)
+    pubsub.subscribe(CHANNEL_NAME)
+    logging.info("Subscribed to channel %s, ready to process messages", CHANNEL_NAME)
+    for message in pubsub.listen():
+        process_message(message)
+
+if __name__ == '__main__':
+    # Init logging
+    logging.basicConfig()
+    logging.getLogger().setLevel(logging.INFO)
+
+    # Loop forever processing messages
+    subscriber_loop()

--- a/server.py
+++ b/server.py
@@ -105,18 +105,16 @@ def cleanup():
 def reboot_screenly():
     """
     Background task to reboot Screenly-OSE.
-    @TODO. Fix me. This will not work in Docker.
     """
-    sh.sudo('shutdown', '-r', 'now', _bg=True)
+    r.publish('hostcmd', 'reboot')
 
 
 @celery.task
 def shutdown_screenly():
     """
     Background task to shutdown Screenly-OSE.
-    @TODO. Fix me. This will not work in Docker.
     """
-    sh.sudo('shutdown', 'now', _bg=True)
+    r.publish('hostcmd', 'shutdown')
 
 
 @celery.task

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -415,7 +415,9 @@
                         <button id="btn-reset" class="btn btn-danger btn-long" type="button">Reset wifi</button>
                     </div>
                 </div>
+            {% endif %}
 
+            {% if not (context.is_balena) %}
                 {# System controls #}
                 <div id="system-controls-section" class="col-12 mb-5">
                     <h4 class="page-header">


### PR DESCRIPTION

This change implements a mechanism for executing a restricted set of commands on the host from within the screenly Docker containers by using a very simple host agent process, which requires only 2 packaged dependencies (python3 and python3-redis) from the standard Raspbian repositories.

Initially, this functionality is used to implement the previously disabled reboot and shutdown features. However, this could fairly easily be expanded to re-implement the USB asset loading functionality.

Furthermore, this change removes the reinstallation of build-essential, as /usr/lib/gcc/arm-linux-gnueabihf/4.9/cc1plus does not exist after reinstalling such and screenly builds without error.