### PR TITLE
Remove /etc/localtime in viewer container, such that the Docker mount takes precedence

### DIFF
--- a/docker/Dockerfile.viewer
+++ b/docker/Dockerfile.viewer
@@ -148,6 +148,8 @@ ENV GIT_BRANCH=$GIT_BRANCH
 
 RUN useradd -g video viewer
 
+RUN rm -f /etc/localtime
+
 WORKDIR /usr/src/app
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app/


### PR DESCRIPTION
This remediates an issue where the timezone used by the QTWebView instance within the viewer container is always UTC, regardless of the host timezone.