### PR TITLE
Add timezone configuration through environment variables

### DIFF
--- a/bin/start_viewer.sh
+++ b/bin/start_viewer.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Default to UTC if no TIMEZONE env variable is set
+echo "Setting time zone to ${TIMEZONE=UTC}"
+# This only works on Debian-based images
+echo "${TIMEZONE}" > /etc/timezone
+dpkg-reconfigure tzdata
+
 # Fixes permission on /dev/vchiq
 chgrp -f video /dev/vchiq
 chmod -f g+rwX /dev/vchiq


### PR DESCRIPTION
When deploying via Balena you can define environment variables. This change applies the `TIMEZONE` variable as a timezone for the viewer so that pages using the internal clock will display the correct time for the timezone.
Taken from the official Balena timezone example: https://github.com/balena-io-examples/balena-timezone/blob/master/start.sh