### PR TITLE
Added autocomplete attributes to form elements

### DIFF
--- a/templates/auth_basic.html
+++ b/templates/auth_basic.html
@@ -5,10 +5,10 @@
 <div class="row">
     <div class="form-group col-6" id="password_group">
         <label class="small text-secondary">Password</label>
-        <input class="form-control" name="password" type="password" value="">
+        <input class="form-control" name="password" type="password" value="" autocomplete="new-password">
     </div>
     <div class="form-group col-6" id="password2_group">
         <label class="small text-secondary">Confirm Password</label>
-        <input class="form-control" name="password2" type="password" value="">
+        <input class="form-control" name="password2" type="password" value="" autocomplete="new-password">
     </div>
 </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -34,7 +34,7 @@
                         <div class="form-group">
                             <label class="small text-secondary">Player name</label>
                             <input class="form-control" name="player_name" type="text"
-                                   value="{{ context.player_name }}">
+                                   value="{{ context.player_name }}" autocomplete="off">
                         </div>
                         <div class="form-inline">
                             <label>Show splash screen</label>


### PR DESCRIPTION
Added `autocomplete="off"` to player_name field
Added `autocomplete="new-password"` to both the auth password and password2 fields

These have been added to stop auto filling username and passwords from being entered. This is mainly an issue when you go to make changes to other settings and it renames the player, and tries to change the password if using basic authentication.