### PR TITLE
Fix container builds

### DIFF
--- a/bin/build_containers.sh
+++ b/bin/build_containers.sh
@@ -45,6 +45,7 @@ for container in base server celery redis websocket nginx; do
     fi
 done
 
+# @TODO Simplify this setup with https://docs.docker.com/desktop/multi-arch/
 echo "Building viewer for different architectures..."
 for pi_version in pi4 pi3 pi2 pi1; do
     echo "Building viewer container for $pi_version"

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,6 +1,6 @@
 FROM screenly/srly-ose-base
 
-ADD requirements/requirements.txt /tmp/requirements.txt
+COPY requirements/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 RUN mkdir -p /usr/src/app

--- a/docker/Dockerfile.viewer
+++ b/docker/Dockerfile.viewer
@@ -100,7 +100,7 @@ RUN apt-get update && \
     apt-get clean
 
 # Install Python requirements
-ADD requirements/requirements.viewer.txt /tmp/requirements.txt
+COPY requirements/requirements.viewer.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Works around issue with `curl`

--- a/requirements/requirements-websocket.txt
+++ b/requirements/requirements-websocket.txt
@@ -1,4 +1,4 @@
 Flask==1.1.2
 gevent-websocket==0.10.1
-gevent==20.9.0
+gevent==21.12.0
 pytz==2022.2.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -19,7 +19,7 @@ gevent==21.12.0
 greenlet==1.0.0
 gunicorn==19.10.0
 hurry.filesize==0.9
-kombu==5.2.4
+kombu==4.6.11
 mixpanel==4.7.0
 netifaces==0.10.9
 psutil==5.7.3
@@ -30,7 +30,7 @@ python-dateutil==2.8.1
 pytz==2022.2.1
 pyzmq==19.0.2
 redis==3.5.3
-requests[security]==2.28.1
+requests[security]==2.27.1
 sh==1.8
 six==1.15.0
 urllib3==1.25.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,16 +6,16 @@ MarkupSafe==1.1.1
 PyYAML==5.4
 Werkzeug==1.0.1
 cec==0.2.7
-celery==5.2.7
-certifi==2022.6.15.1
+celery==4.4.7
+certifi==2021.10.8
 cffi==1.14.4
-click==8.1.3
+click==7.1.2
 configparser==4.0.2
 cryptography==3.3.2
 flask-restful-swagger-2==0.35
 flask-swagger-ui==3.36.0
 gevent-websocket==0.10.1
-gevent==20.12.1
+gevent==21.12.0
 greenlet==1.0.0
 gunicorn==19.10.0
 hurry.filesize==0.9
@@ -33,5 +33,5 @@ redis==3.5.3
 requests[security]==2.28.1
 sh==1.8
 six==1.15.0
-urllib3==1.26.5
+urllib3==1.25.0
 youtube-dl>=2021.12.17

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -16,7 +16,7 @@ flask-restful-swagger-2==0.35
 flask-swagger-ui==3.36.0
 gevent-websocket==0.10.1
 gevent==21.12.0
-greenlet==1.0.0
+greenlet==1.1.0
 gunicorn==19.10.0
 hurry.filesize==0.9
 kombu==4.6.11

--- a/requirements/requirements.viewer.txt
+++ b/requirements/requirements.viewer.txt
@@ -12,7 +12,7 @@ python-vlc==3.0.11115
 pytz==2022.2.1
 pyzmq==19.0.2
 redis==3.5.3
-requests[security]==2.28.1
+requests[security]==2.27.1
 sh==1.8
 uptime==3.0.1
 urllib3==1.25.0

--- a/requirements/requirements.viewer.txt
+++ b/requirements/requirements.viewer.txt
@@ -1,6 +1,6 @@
 Flask==1.1.2
 cec==0.2.7
-certifi==2022.6.15.1
+certifi==2021.10.8
 configparser==4.0.2
 cryptography==3.3.2
 idna==2.6
@@ -15,4 +15,4 @@ redis==3.5.3
 requests[security]==2.28.1
 sh==1.8
 uptime==3.0.1
-urllib3==1.26.5
+urllib3==1.25.0

--- a/webview/Dockerfile
+++ b/webview/Dockerfile
@@ -5,6 +5,7 @@ FROM --platform=linux/arm/v7 balenalib/rpi-raspbian:buster as builder
 # to make things work.
 RUN apt-get update && \
     apt-get install -y \
+        apt-utils \
         firebird-dev \
         freetds-dev \
         gstreamer-tools \

--- a/webview/README.md
+++ b/webview/README.md
@@ -4,7 +4,7 @@ Since our entire build environment resides inside a Docker container, you don't 
 
 ```
 $ cd webview
-$ docker build \
+$ docker buildx build \
     --build-arg GIT_HASH=$(git rev-parse --short HEAD) \
     -t qt-builder .
 ```


### PR DESCRIPTION
## Changes

* Closes #1593. (Kudos to @emilyyap for patch.)
* Rolls back a number of Python package updates as they were not available in Python 2.

I successfully built (and pushed) new containers on a Pi 4. For whatever reason, cross-compiling still doesn't work.