### PR TITLE
Bring back test suite runs on GitHub actions

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -9,9 +9,32 @@ on:
       - 'webview/**'
       - '.github/workflows/build-webview.yaml'
       - README.md
+  pull_request:
+    branches:
+      - master
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare the test environment.
+        run: |
+          mkdir -p ~/.screenly ~/.config/uzbl/ ~/screenly_assets /tmp/USB/cleanup_folder
+          curl https://www.screenly.io/upload/ose-logo.png > /tmp/image.png
+          cp /tmp/image.png /tmp/USB/image.png
+          cp /tmp/image.png /tmp/USB/cleanup_folder/image.png
+          cp tests/config/ffserver.conf /etc/ffserver.conf
+          python server.py &
+          server_pid=$!
+          sleep 3
+
+      - name: Run the unit tests.
+        run: |
+          find . ! -path "*/rtmplite/*" -name \*.py -exec pep8 --ignore=E402,E501,E731 {} +
+          nosetests -v -a '!fixme'
+
   buildx:
+    needs: test
     strategy:
       matrix:
         board: ['pi1', 'pi2', 'pi3', 'pi4']

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+prepare () {
+    mkdir -p ~/.screenly ~/.config/uzbl/ ~/screenly_assets /tmp/USB/cleanup_folder
+    # cp ansible/roles/screenly/files/uzbl-config ~/.config/uzbl/config-screenly
+    cp ansible/roles/screenly/files/screenly.conf ~/.screenly/
+    cp ansible/roles/screenly/files/screenly.db ~/.screenly/
+    cp bin/install.sh /usr/local/sbin/upgrade_screenly.sh
+    chmod 0700 /usr/local/sbin/upgrade_screenly.sh
+    echo -e "[local]\nlocalhost ansible_connection=local" > ansible/localhost
+    curl https://www.screenly.io/upload/ose-logo.png > /tmp/image.png
+    cp /tmp/image.png /tmp/USB/image.png
+    cp /tmp/image.png /tmp/USB/cleanup_folder/image.png
+    curl https://www.screenly.io/upload/ose-logo.png > ~/screenly_assets/image.tmp
+    curl https://www.screenly.io/upload/big_buck_bunny_720p_10mb.flv > /tmp/video.flv
+    cp tests/assets/asset.mov /tmp/asset.mov
+    export DISPLAY=:99.0
+    # /sbin/start-stop-daemon --start --quiet \
+    #     --pidfile /tmp/custom_xvfb_99.pid --make-pidfile \
+    #     --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
+    cp tests/config/ffserver.conf /etc/ffserver.conf
+    # /usr/bin/ffserver -f /etc/ffserver.conf &
+    # sleep 3
+    python server.py &
+    sleep 3 # give xvfb some time to start
+}
+
+execute_tests () {
+    find . ! -path "*/rtmplite/*" -name \*.py -exec pep8 --ignore=E402,E501,E731 {} +
+    nosetests -v -a '!fixme'
+    # ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
+    # python -m SimpleHTTPServer 8081 &
+    # sleep 3
+    # bash static/spec/runner.sh
+}
+
+prepare
+execute_tests

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -2,37 +2,23 @@
 
 prepare () {
     mkdir -p ~/.screenly ~/.config/uzbl/ ~/screenly_assets /tmp/USB/cleanup_folder
-    # cp ansible/roles/screenly/files/uzbl-config ~/.config/uzbl/config-screenly
-    cp ansible/roles/screenly/files/screenly.conf ~/.screenly/
-    cp ansible/roles/screenly/files/screenly.db ~/.screenly/
-    cp bin/install.sh /usr/local/sbin/upgrade_screenly.sh
-    chmod 0700 /usr/local/sbin/upgrade_screenly.sh
-    echo -e "[local]\nlocalhost ansible_connection=local" > ansible/localhost
     curl https://www.screenly.io/upload/ose-logo.png > /tmp/image.png
     cp /tmp/image.png /tmp/USB/image.png
     cp /tmp/image.png /tmp/USB/cleanup_folder/image.png
-    curl https://www.screenly.io/upload/ose-logo.png > ~/screenly_assets/image.tmp
-    curl https://www.screenly.io/upload/big_buck_bunny_720p_10mb.flv > /tmp/video.flv
-    cp tests/assets/asset.mov /tmp/asset.mov
-    export DISPLAY=:99.0
-    # /sbin/start-stop-daemon --start --quiet \
-    #     --pidfile /tmp/custom_xvfb_99.pid --make-pidfile \
-    #     --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
     cp tests/config/ffserver.conf /etc/ffserver.conf
-    # /usr/bin/ffserver -f /etc/ffserver.conf &
-    # sleep 3
     python server.py &
-    sleep 3 # give xvfb some time to start
+    server_pid=$!
+    sleep 3
 }
 
 execute_tests () {
     find . ! -path "*/rtmplite/*" -name \*.py -exec pep8 --ignore=E402,E501,E731 {} +
     nosetests -v -a '!fixme'
-    # ansible-playbook --syntax-check -i ansible/localhost ansible/site.yml
-    # python -m SimpleHTTPServer 8081 &
-    # sleep 3
-    # bash static/spec/runner.sh
 }
 
 prepare
 execute_tests
+
+if [ -n "$server_pid" ]; then
+    kill $server_pid
+fi

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,22 @@
+version: "2.2"
+services:
+  srly-ose-base:
+    image: screenly/srly-ose-base:latest-x86
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.base.dev
+      cache_from:
+        - screenly/srly-ose-base:latest-x86
+
+  srly-ose-test:
+    image: screenly/srly-ose-server:latest-x86
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.test
+      cache_from:
+        - screenly/srly-ose-base:latest-x86
+        - screenly/srly-ose-server:latest-x86
+    depends_on:
+      - srly-ose-base
+    stdin_open: true
+    tty: true

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,0 +1,18 @@
+FROM screenly/srly-ose-base:latest-x86
+
+ADD requirements/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+ADD requirements/requirements.dev.txt /tmp/requirements.dev.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.dev.txt
+
+RUN mkdir -p /usr/src/app
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+
+ARG GIT_HASH
+ENV GIT_HASH=$GIT_HASH
+ARG GIT_SHORT_HASH
+ENV GIT_SHORT_HASH=$GIT_SHORT_HASH
+ARG GIT_BRANCH
+ENV GIT_BRANCH=$GIT_BRANCH


### PR DESCRIPTION
### General

- Development will be continued on #1616.

### Running Tests Locally (Dockerized)

```bash
docker-compose -f docker-compose.test..yml up -d
docker-compose -f docker-compose.test.yml exec srly-ose-test bash bin/run_tests.sh
```

### Possible Next Steps

- Remove any unnecessary commands in `bin/run_tests.sh`.
- Ensure that all `nose` tests are passing.
- Modify the GitHub Actions workflow file so that tests could be run.
- Speed up the GitHub Actions workflow.
- Modify `README.md` and/or any relevant docs.
- If applicable, restore the command for running PhantomJS tests.
- Make local tests idempotent. Results should be the same after running it multiple times.