### PR TITLE
Tjm/fix helper

### DIFF
--- a/lib/diagnostics.py
+++ b/lib/diagnostics.py
@@ -3,11 +3,9 @@
 import os
 import sh
 import sqlite3
-import re
 import utils
 import cec
 from lib import raspberry_pi_helper
-from utils import connect_to_redis
 from pprint import pprint
 from datetime import datetime
 
@@ -84,6 +82,7 @@ def get_git_short_hash():
 def get_git_hash():
     return os.getenv('GIT_HASH')
 
+
 def try_connectivity():
     urls = [
         'http://www.google.com',
@@ -125,28 +124,28 @@ def get_raspberry_model(raspberry_pi_revision):
     """
     Quick DRY workaround. Needs to be refactored later.
     """
-    return raspberry_pi_helper.lookup_raspberry_pi_revision(raspberry_pi_revision)['model']
+    return raspberry_pi_helper.lookup_raspberry_pi_revision(raspberry_pi_revision).get('model', False)
 
 
 def get_raspberry_revision(raspberry_pi_revision):
     """
     Quick DRY workaround. Needs to be refactored later.
     """
-    return raspberry_pi_helper.lookup_raspberry_pi_revision(raspberry_pi_revision)['revision']
+    return raspberry_pi_helper.lookup_raspberry_pi_revision(raspberry_pi_revision).get('revision', False)
 
 
 def get_raspberry_ram(raspberry_pi_revision):
     """
     Quick DRY workaround. Needs to be refactored later.
     """
-    return raspberry_pi_helper.lookup_raspberry_pi_revision(raspberry_pi_revision)['ram']
+    return raspberry_pi_helper.lookup_raspberry_pi_revision(raspberry_pi_revision).get('ram', False)
 
 
 def get_raspberry_manufacturer(raspberry_pi_revision):
     """
     Quick DRY workaround. Needs to be refactored later.
     """
-    return raspberry_pi_helper.lookup_raspberry_pi_revision(raspberry_pi_revision)['manufacturer']
+    return raspberry_pi_helper.lookup_raspberry_pi_revision(raspberry_pi_revision).get('manufacturer', False)
 
 
 def compile_report():

--- a/lib/raspberry_pi_helper.py
+++ b/lib/raspberry_pi_helper.py
@@ -101,6 +101,10 @@ def lookup_raspberry_pi_revision(revision):
                    'model': 'Model 4B',
                    'ram': '1GB',
                    'revision': '1.1'},
+        'a03115': {'manufacturer': 'Sony UK',
+                   'model': 'Model 4B',
+                   'ram': '1GB',
+                   'revision': '1.5'},
         'a21041': {'manufacturer': 'Embest',
                    'model': 'Model 2B',
                    'ram': '1GB',
@@ -172,7 +176,11 @@ def lookup_raspberry_pi_revision(revision):
         'c03115': {'manufacturer': 'Sony UK',
                    'model': 'Model 4B',
                    'ram': '4GB',
-                   'revision': '1.5'}
+                   'revision': '1.5'},
+        'unknown': {'manufacturer': 'Unknown',
+                    'model': 'Unknown',
+                    'ram': '0GB',
+                    'revision': '0.0'}
     }
 
-    return database.get(revision, 'Unknown Raspberry Pi version.')
+    return database.get(revision) or database.get('unknown')


### PR DESCRIPTION
Currently, when trying to run against a Pi 4B Rev 1.5 with 1GB, the viewer container will continuously restart. The method `lookup_raspberry_pi_revision` returns a str when the lookup fails. This in turn causes `get_raspberry_model` to cause a TypeError exception, since it is assuming the return is a dict. Adding the new type, but also adding some protection code.
 
May fix https://github.com/Screenly/screenly-ose/issues/1580