### PR TITLE
Update balena.yml to visualize the logo on balenaHub

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -22,14 +22,14 @@ assets:
   repository:
     type: "blob.asset"
     data:
-      url: "https://github.com/Screenly/screenly-ose/"
+      url: "https://github.com/mpous/screenly-ose/"
   logo:
     type: "blob.asset"
     data:
-      url: >-
-        "https://raw.githubusercontent.com/Screenly/screenly-ose/master/static/img/ose-logo.png"
+      url: "https://raw.githubusercontent.com/Screenly/screenly-ose/master/static/img/ose-logo.png"
 data:
+  defaultDeviceType: raspberrypi3
   supportedDeviceTypes:
     - raspberrypi3
     - fincm3
-version: 0.0.1
+version: 0.0.2

--- a/balena.yml
+++ b/balena.yml
@@ -28,3 +28,4 @@ assets:
     data:
       url: >-
         "https://raw.githubusercontent.com/Screenly/screenly-ose/master/static/img/ose-logo.png"
+data:

--- a/balena.yml
+++ b/balena.yml
@@ -22,7 +22,7 @@ assets:
   repository:
     type: "blob.asset"
     data:
-      url: "https://github.com/mpous/screenly-ose/"
+      url: "https://github.com/Screenly/screenly-ose/"
   logo:
     type: "blob.asset"
     data:

--- a/balena.yml
+++ b/balena.yml
@@ -29,3 +29,7 @@ assets:
       url: >-
         "https://raw.githubusercontent.com/Screenly/screenly-ose/master/static/img/ose-logo.png"
 data:
+  supportedDeviceTypes:
+    - raspberrypi3
+    - fincm3
+version: 0.0.1

--- a/balena.yml
+++ b/balena.yml
@@ -27,9 +27,3 @@ assets:
     type: "blob.asset"
     data:
       url: "https://raw.githubusercontent.com/Screenly/screenly-ose/master/static/img/ose-logo.png"
-data:
-  defaultDeviceType: raspberrypi3
-  supportedDeviceTypes:
-    - raspberrypi3
-    - fincm3
-version: 0.0.2


### PR DESCRIPTION
I modified the `balena.yml` file to see the logo on balenaHub.

Change-type: patch
Signed-off-by: Marc Pous <marc@balena.io>