### PR TITLE
Makes path/path-ignore consistent

### DIFF
--- a/.github/workflows/build-webview.yaml
+++ b/.github/workflows/build-webview.yaml
@@ -7,8 +7,7 @@ on:
     paths:
       - '.github/workflows/build-webview.yaml'
       - 'webview/**'
-    paths-ignore:
-      - 'webview/README.md'
+      - '!webview/README.md'
 
 jobs:
   build-docker-image:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -5,10 +5,13 @@ on:
     branches:
       - master
       - production
-    paths-ignore:
-      - 'webview/**'
-      - '.github/workflows/build-webview.yaml'
-      - README.md
+    paths:
+      - '/**'
+      - '!webview/**'
+      - '!.github/workflows/build-webview.yaml'
+      - '!README.md'
+      - '!/bin'
+      - '!/docks'
 
 jobs:
   run-tests:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -11,7 +11,7 @@ on:
       - '!.github/workflows/build-webview.yaml'
       - '!README.md'
       - '!/bin'
-      - '!/docks'
+      - '!/docs'
 
 jobs:
   run-tests:


### PR DESCRIPTION
* Resolves issue with mixing `paths` and `paths-ignore` ([example run](https://github.com/Screenly/screenly-ose/actions/runs/3322205561)).
* Adds more excludes