### PR TITLE
Removes `::set-output` feature

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -84,28 +84,20 @@ jobs:
           echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
           echo "GIT_SHORT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - name: Set buildx args
-        id: buildx-args
-        run: |
-          # Define the build arguments
-          echo ::set-output name=buildx_args::\
-            --platform "$TARGET_PLATFORM" \
-            --output "type=image,push=true" \
-            --cache-from "type=local,src=/tmp/.buildx-cache" \
-            --cache-to "type=local,dest=/tmp/.buildx-cache" \
-            --build-arg "PI_VERSION=${{ matrix.board }}" \
-            --build-arg "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-            --build-arg "GIT_HASH=$GITHUB_SHA" \
-            --build-arg "GIT_SHORT_HASH=$GIT_SHORT_HASH" \
-            --build-arg "GIT_BRANCH=$GITHUB_REF_NAME"
-
-
       - name: Building containers
         run: |
           for container in base server celery redis websocket nginx viewer; do
             echo "Building container $container"
             docker buildx build \
-              ${{ steps.buildx-args.outputs.buildx_args }} \
+              --platform "$TARGET_PLATFORM" \
+              --output "type=image,push=true" \
+              --cache-from "type=local,src=/tmp/.buildx-cache" \
+              --cache-to "type=local,dest=/tmp/.buildx-cache" \
+              --build-arg "PI_VERSION=${{ matrix.board }}" \
+              --build-arg "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+              --build-arg "GIT_HASH=$GITHUB_SHA" \
+              --build-arg "GIT_SHORT_HASH=$GIT_SHORT_HASH" \
+              --build-arg "GIT_BRANCH=$GITHUB_REF_NAME" \
               -f "docker/Dockerfile.$container" \
               -t "screenly/srly-ose-$container:$GIT_SHORT_HASH-${{ matrix.board }}" \
               -t "screenly/srly-ose-$container:$DOCKER_TAG" .


### PR DESCRIPTION
The `::set-output` feature has been [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This PR remove sthe use of this feature.