### PR TITLE
fix containers not starting after install

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -188,9 +188,6 @@ cd /home/pi/screenly/ansible
 
 sudo -E ansible-playbook site.yml "${EXTRA_ARGS[@]}"
 
-# Pull down and install containers
-/home/pi/screenly/bin/upgrade_containers.sh
-
 sudo apt-get autoclean
 sudo apt-get clean
 sudo docker system prune -f
@@ -268,6 +265,9 @@ check_defaultpw () {
 }
 
 check_defaultpw;
+
+# Pull down and install containers
+/home/pi/screenly/bin/upgrade_containers.sh
 
 echo -e "Screenly version: $(git rev-parse --abbrev-ref HEAD)@$(git rev-parse --short HEAD)\n$(lsb_release -a)" > ~/version.md
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -188,6 +188,9 @@ cd /home/pi/screenly/ansible
 
 sudo -E ansible-playbook site.yml "${EXTRA_ARGS[@]}"
 
+# Pull down and install containers
+/home/pi/screenly/bin/upgrade_containers.sh
+
 sudo apt-get autoclean
 sudo apt-get clean
 sudo docker system prune -f
@@ -265,9 +268,6 @@ check_defaultpw () {
 }
 
 check_defaultpw;
-
-# Pull down and install containers
-/home/pi/screenly/bin/upgrade_containers.sh
 
 echo -e "Screenly version: $(git rev-parse --abbrev-ref HEAD)@$(git rev-parse --short HEAD)\n$(lsb_release -a)" > ~/version.md
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.server
-      network: host
+      network: bridge
     environment:
       - HOME=/data
       - LISTEN=0.0.0.0
@@ -24,7 +24,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.viewer
-      network: host
+      network: bridge
     depends_on:
       - srly-ose-server
     environment:
@@ -42,7 +42,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.websocket
-      network: host
+      network: bridge
     depends_on:
       - srly-ose-server
     environment:
@@ -57,7 +57,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.celery
-      network: host
+      network: bridge
     depends_on:
       - srly-ose-server
       - redis
@@ -76,7 +76,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.redis
-      network: host
+      network: bridge
     ports:
       - 127.0.0.1:6379:6379
     restart: always
@@ -88,7 +88,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.nginx
-      network: host
+      network: bridge
     ports:
       - 80:80
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.server
-      network: bridge
     environment:
       - HOME=/data
       - LISTEN=0.0.0.0
@@ -24,7 +23,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.viewer
-      network: bridge
     depends_on:
       - srly-ose-server
     environment:
@@ -42,7 +40,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.websocket
-      network: bridge
     depends_on:
       - srly-ose-server
     environment:
@@ -57,7 +54,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.celery
-      network: bridge
     depends_on:
       - srly-ose-server
       - redis
@@ -76,7 +72,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.redis
-      network: bridge
     ports:
       - 127.0.0.1:6379:6379
     restart: always
@@ -88,7 +83,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.nginx
-      network: bridge
     ports:
       - 80:80
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
-version: "2"
+version: "2.2"
 services:
   srly-ose-server:
     image: screenly/srly-ose-server
     build:
       context: .
       dockerfile: docker/Dockerfile.server
+      network: host
     environment:
       - HOME=/data
       - LISTEN=0.0.0.0
@@ -23,6 +24,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.viewer
+      network: host
     depends_on:
       - srly-ose-server
     environment:
@@ -40,6 +42,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.websocket
+      network: host
     depends_on:
       - srly-ose-server
     environment:
@@ -54,6 +57,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.celery
+      network: host
     depends_on:
       - srly-ose-server
       - redis
@@ -72,6 +76,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.redis
+      network: host
     ports:
       - 127.0.0.1:6379:6379
     restart: always
@@ -83,6 +88,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.nginx
+      network: host
     ports:
       - 80:80
     environment:


### PR DESCRIPTION
For some reason, I think the system was pruning the containers before they were starting, because all fresh installs I did would not have containers starting after the installation reboot, `docker ps` would show no containers, and running `./screenly/bin/upgrade_containers.sh` was building and starting them, but that was a manual after the fact process, so I customized the `install.sh` and removed the `sudo docker system prune -f` from the install script and the containers were starting normal after installation.

This PR just moves the bringing up of the containers to the end of the installation script/process just to make sure they are brought up before the reboot.