### PR TITLE
Feature/make swap on disc configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,13 @@ There are additional switches to configure the installation of Screenly OSE. To 
 ### Example
 To set the variable `screenly_system_disable_swap_on_disk` to `true` and `something_else` to `false`, run the installer the following way:
 ```bash
-$ OVERRIDE_ANSIBLE_VARS="screenly_system_disable_swap_on_disk=false something_else=true" bash <(curl -sL https://install-ose.srly.io)
+$ OVERRIDE_ANSIBLE_VARS="screenly_system_disable_swap_on_disk=false something_else=true" \
+    bash <(curl -sL https://install-ose.srly.io)
 ```
 The same result with a `.env` file:
 ```bash
-echo 'OVERRIDE_ANSIBLE_VARS="screenly_system_disable_swap_on_disk=false something_else=true"' >> .env
-bash <(curl -sL https://install-ose.srly.io)
+$ echo 'OVERRIDE_ANSIBLE_VARS="screenly_system_disable_swap_on_disk=false something_else=true"' >> .env
+$ bash <(curl -sL https://install-ose.srly.io)
 ```
 ### Available Variables
 | Variable name                        | What it does | Default value |

--- a/README.md
+++ b/README.md
@@ -97,3 +97,21 @@ $ docker-compose \
     -f docker-compose.test.yml \
     exec -T srly-ose-test nosetests -v -a '!fixme'
 ```
+
+## Installation options for advanced users
+There are additional switches to configure the installation of Screenly OSE. To set the ansible extra vars supplied to the `ansible-playbook` run, set the `OVERRIDE_ANSIBLE_VARS` variable to your desired value(s). This can either be done by setting it in a `.env` file in the folder the installation gets run in or by supplying the corresponding variables to the bash command.
+
+### Example
+To set the variable `screenly_system_disable_swap_on_disk` to `true` and `something_else` to `false`, run the installer the following way:
+```bash
+$ OVERRIDE_ANSIBLE_VARS="screenly_system_disable_swap_on_disk=false something_else=true" bash <(curl -sL https://install-ose.srly.io)
+```
+The same result with a `.env` file:
+```bash
+echo 'OVERRIDE_ANSIBLE_VARS="screenly_system_disable_swap_on_disk=false something_else=true"' >> .env
+bash <(curl -sL https://install-ose.srly.io)
+```
+### Available Variables
+| Variable name                        | What it does | Default value |
+|--------------------------------------|--------------|---------------|
+| screenly_system_disable_swap_on_disk | Should the setup disable the `dphys-swapfile` service to prolong the livetime of the sd-card? | true |

--- a/ansible/roles/system/tasks/main.yml
+++ b/ansible/roles/system/tasks/main.yml
@@ -197,7 +197,6 @@
 - name: Remove deprecated apt dependencies
   apt:
     name:
-      - dphys-swapfile
       - lightdm
       - lightdm-gtk-greeter
       - matchbox
@@ -211,6 +210,23 @@
       - x11-xserver-utils
       - xserver-xorg
     state: absent
+
+- name: Disable dphys-swapfile systemd service
+  systemd:
+    name: dphys-swapfile.service
+    masked: true
+    enabled: false
+  when: screenly_system_disable_swap_on_disk
+
+- name: Disable swap
+  command: /sbin/swapoff --all removes=/var/swap
+  when: screenly_system_disable_swap_on_disk
+
+- name: Remove swapfile from disk
+  file:
+    path: /var/swap
+    state: absent
+  when: screenly_system_disable_swap_on_disk
 
 - name: Make sure distro package of Docker is absent
   apt:
@@ -296,11 +312,3 @@
     mode: 0644
     owner: root
     group: root
-
-- name: Disable swap
-  command: /sbin/swapoff --all removes=/var/swap
-
-- name: Remove swapfile from disk
-  file:
-    path: /var/swap
-    state: absent

--- a/ansible/roles/system/vars/main.yml
+++ b/ansible/roles/system/vars/main.yml
@@ -1,0 +1,3 @@
+---
+
+screenly_system_disable_swap_on_disk: true

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -97,6 +97,13 @@ export BRANCH="master"
       EXTRA_ARGS=("--skip-tags" "system-upgrade")
   fi
 
+  if [ ! -z "$OVERRIDE_ANSIBLE_VARS" ]; then
+    echo -e "Setting ansible extra vars to: $OVERRIDE_ANSIBLE_VARS"
+    ANSIBLE_EXTRA_VARS=("--extra-vars" "$OVERRIDE_ANSIBLE_VARS")
+  else
+    ANSIBLE_EXTRA_VARS=""
+  fi
+
 elif [ "$WEB_UPGRADE" = true ]; then
   if [ -z "${BRANCH}" ]; then
     if [ "$BRANCH_VERSION" = "latest" ]; then
@@ -186,7 +193,7 @@ sudo -u pi ansible localhost \
     -a "repo=$REPOSITORY dest=/home/pi/screenly version=$BRANCH force=no"
 cd /home/pi/screenly/ansible
 
-sudo -E ansible-playbook site.yml "${EXTRA_ARGS[@]}"
+sudo -E ansible-playbook site.yml "${EXTRA_ARGS[@]}" "${ANSIBLE_EXTRA_VARS[@]}"
 
 # Pull down and install containers
 /home/pi/screenly/bin/upgrade_containers.sh


### PR DESCRIPTION
**Attention: This PR has not been tested yet!** I sadly don't have a Pi available. If somebody else wants to test it, please let me know so I can help to debug any problems.

This feature allows to configure aspects of the ansible based setup. The first use case ist to not disable the dphys swapfile removal.

Also: I think it is better to disable and mask the `dphys-swapfile` service. If it only gets removed, its always possible that a upgrade will re-install the package, since it is a Raspbian base OS package. If a service gets disabled by a user (in this case the screenly ose setup), it will remain even if a update is installed.